### PR TITLE
feat/better_kwargs

### DIFF
--- a/hivemind_bus_client/identity.py
+++ b/hivemind_bus_client/identity.py
@@ -68,6 +68,14 @@ class NodeIdentity:
     def default_master(self, val):
         self.IDENTITY_FILE["default_master"] = val
 
+    @property
+    def default_port(self):
+        return self.IDENTITY_FILE.get("default_port")
+
+    @default_port.setter
+    def default_port(self, val):
+        self.IDENTITY_FILE["default_port"] = val
+
     def save(self):
         self.IDENTITY_FILE.store()
 


### PR DESCRIPTION
- internal bus is now a kwarg to allow to easily connect an existing OVOS bus, instead of always using a FakeBus

- allow port and host to come from identity

- add identity-test script validate info

- typing


test with


    # $ hivemind-client set-identity --key 3d20b5188aa0157562b2bc2e7d966127 --password 6f81688ec095bd00dee63aca13dd091f --host 0.0.0.0 --port 5678 --siteid test

    # $ cat /home/miro/.config/hivemind/_identity.json
    # {
    #     "password": "6f81688ec095bd00dee63aca13dd091f",
    #     "access_key": "3d20b5188aa0157562b2bc2e7d966127",
    #     "site_id": "test",
    #     "default_port": 5678,
    #     "default_master": "ws://0.0.0.0"
    # }

    # $ hivemind-client test-identity