### PR TITLE
feat:add chacha20 cipher + z85 encoding

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -18,7 +18,8 @@ from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.serialization import HiveMindBinaryPayloadType
 from hivemind_bus_client.serialization import get_bitstring, decode_bitstring
 from hivemind_bus_client.util import serialize_message
-from hivemind_bus_client.encryption import encrypt_as_json, decrypt_from_json, encrypt_bin, decrypt_bin, JsonCiphers, BinaryCiphers
+from hivemind_bus_client.encryption import (encrypt_as_json, decrypt_from_json, encrypt_bin, decrypt_bin,
+                                            SupportedEncodings, SupportedCiphers)
 from poorman_handshake.asymmetric.utils import encrypt_RSA, load_RSA_key, sign_RSA
 
 
@@ -104,8 +105,8 @@ class HiveMessageBusClient(OVOSBusClient):
                  internal_bus: Optional[OVOSBusClient] = None,
                  bin_callbacks: BinaryDataCallbacks = BinaryDataCallbacks()):
         self.bin_callbacks = bin_callbacks
-        self.json_cipher = JsonCiphers.JSON_HEX_AES_GCM_128  # server defaults before it was made configurable
-        self.bin_cipher = BinaryCiphers.BINARY_AES_GCM_128  # server defaults before it was made configurable
+        self.json_encoding = SupportedEncodings.JSON_HEX  # server defaults before it was made configurable
+        self.cipher = SupportedCiphers.AES_GCM  # server defaults before it was made configurable
 
         self.identity = identity or None
         self._password = password
@@ -273,11 +274,12 @@ class HiveMessageBusClient(OVOSBusClient):
         if self.crypto_key:
             # handle binary encryption
             if isinstance(message, bytes):
-                message = decrypt_bin(self.crypto_key, message, cipher=self.bin_cipher)
+                message = decrypt_bin(self.crypto_key, message, cipher=self.cipher)
             # handle json encryption
             elif "ciphertext" in message:
                 # LOG.debug(f"got encrypted message: {len(message)}")
-                message = decrypt_from_json(self.crypto_key, message, cipher=self.json_cipher)
+                message = decrypt_from_json(self.crypto_key, message,
+                                            cipher=self.cipher, encoding=self.json_encoding)
             else:
                 LOG.debug("Message was unencrypted")
 
@@ -369,14 +371,15 @@ class HiveMessageBusClient(OVOSBusClient):
                                        binary_type=binary_type,
                                        hivemeta=message.metadata)
                 if self.crypto_key:
-                    ws_payload = encrypt_bin(self.crypto_key, bitstr.bytes, cipher=self.bin_cipher)
+                    ws_payload = encrypt_bin(self.crypto_key, bitstr.bytes, cipher=self.cipher)
                 else:
                     ws_payload = bitstr.bytes
                 self.client.send(ws_payload, ABNF.OPCODE_BINARY)
             else:
                 ws_payload = serialize_message(message)
                 if self.crypto_key:
-                    ws_payload = encrypt_as_json(self.crypto_key, ws_payload, cipher=self.json_cipher)
+                    ws_payload = encrypt_as_json(self.crypto_key, ws_payload,
+                                                 cipher=self.cipher, encoding=self.json_encoding)
                 self.client.send(ws_payload)
 
         except WebSocketConnectionClosedException:

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -1,7 +1,7 @@
 import json
 import ssl
 from threading import Event
-from typing import Union, Optional, Callable, Literal
+from typing import Union, Optional, Callable
 
 import pybase64
 from Cryptodome.PublicKey import RSA
@@ -102,13 +102,10 @@ class HiveMessageBusClient(OVOSBusClient):
                  binarize: bool = True,
                  identity: NodeIdentity = None,
                  internal_bus: Optional[OVOSBusClient] = None,
-                 bin_callbacks: BinaryDataCallbacks = BinaryDataCallbacks(),
-                 json_cipher: Literal[JsonCiphers] = JsonCiphers.JSON_HEX_AES_GCM_128, # TODO - default to b64 at some point
-                 bin_cipher: Literal[BinaryCiphers] = BinaryCiphers.BINARY_AES_GCM_128, # TODO - ChaCha20 if certain hardware detected
-                 ):
+                 bin_callbacks: BinaryDataCallbacks = BinaryDataCallbacks()):
         self.bin_callbacks = bin_callbacks
-        self.json_cipher = json_cipher
-        self.bin_cipher = bin_cipher
+        self.json_cipher = JsonCiphers.JSON_HEX_AES_GCM_128  # server defaults before it was made configurable
+        self.bin_cipher = BinaryCiphers.BINARY_AES_GCM_128  # server defaults before it was made configurable
 
         self.identity = identity or None
         self._password = password

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -1,16 +1,30 @@
 import enum
 import json
 from binascii import hexlify, unhexlify
-from typing import Union, Optional, Dict, Any
+from typing import Union, Optional, Dict, Any, Tuple
 
 import pybase64
 from Cryptodome.Cipher import AES, ChaCha20_Poly1305
-
 from cpuinfo import get_cpu_info
-from hivemind_bus_client.exceptions import EncryptionKeyError, DecryptionKeyError, InvalidCipher
+
+from hivemind_bus_client.exceptions import EncryptionKeyError, DecryptionKeyError, InvalidCipher, InvalidKeySize
+
+# Cipher-specific constants
+AES_GCM_KEY_SIZE = 16
+AES_GCM_NONCE_SIZE = 16
+AES_GCM_TAG_SIZE = 16
+CHACHA20_KEY_SIZE = 32
+CHACHA20_NONCE_SIZE = 12
+CHACHA20_TAG_SIZE = 16
 
 
 def cpu_supports_AES() -> bool:
+    """
+    Check if the CPU supports AES encryption.
+
+    Returns:
+        bool: True if AES is supported by the CPU, False otherwise.
+    """
     return "aes" in get_cpu_info()["flags"]
 
 
@@ -66,13 +80,22 @@ def encrypt_as_json(key: Union[str, bytes], data: Union[str, Dict[str, Any]],
 
     bcipher = BinaryCiphers.BINARY_AES_GCM_128 if cipher in aes_ciphers else BinaryCiphers.BINARY_CHACHA20_POLY1305
 
-    ciphertext = encrypt_bin(key, data, cipher=bcipher)
+    try:
+        ciphertext = encrypt_bin(key, data, cipher=bcipher)
+    except InvalidKeySize as e:
+        raise e
+    except Exception as e:
+        raise EncryptionKeyError from e
 
     # extract nonce/tag depending on cipher, sizes are different
     if cipher in aes_ciphers:
-        nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+        nonce, ciphertext, tag = (ciphertext[:AES_GCM_NONCE_SIZE],
+                                  ciphertext[AES_GCM_NONCE_SIZE:-AES_GCM_TAG_SIZE],
+                                  ciphertext[-AES_GCM_TAG_SIZE:])
     else:
-        nonce, ciphertext, tag = ciphertext[:12], ciphertext[12:-16], ciphertext[-16:]
+        nonce, ciphertext, tag = (ciphertext[:CHACHA20_NONCE_SIZE],
+                                  ciphertext[CHACHA20_NONCE_SIZE:-CHACHA20_TAG_SIZE],
+                                  ciphertext[-CHACHA20_TAG_SIZE:])
 
     encoder = pybase64.b64encode if cipher in b64_ciphers else hexlify
 
@@ -90,7 +113,7 @@ def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: J
     Args:
         key (Union[str, bytes]): The decryption key, up to 16 bytes. Longer keys will be truncated.
         data (Union[str, bytes]): The encrypted data as a JSON string or bytes.
-        cipher (Optional[JsonCiphers]): The cipher used for encryption. If None, it is auto-detected.
+        cipher (JsonCiphers): The cipher used for encryption.
 
     Returns:
         str: The decrypted plaintext data.
@@ -99,7 +122,6 @@ def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: J
         InvalidCipher: If an unsupported cipher is provided.
         DecryptionKeyError: If decryption fails due to an invalid key or corrupted data.
     """
-
     aes_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_HEX_AES_GCM_128}
     b64_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_B64_CHACHA20_POLY1305}
 
@@ -111,7 +133,10 @@ def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: J
 
     ciphertext = decoder(data["ciphertext"])
     if "tag" not in data:  # web crypto compatibility
-        ciphertext, tag = ciphertext[:-16], ciphertext[-16:]
+        if bcipher == BinaryCiphers.BINARY_AES_GCM_128:
+            ciphertext, tag = ciphertext[:-AES_GCM_TAG_SIZE], ciphertext[-AES_GCM_TAG_SIZE:]
+        else:
+            ciphertext, tag = ciphertext[:-CHACHA20_TAG_SIZE], ciphertext[-CHACHA20_TAG_SIZE:]
     else:
         tag = decoder(data["tag"])
     nonce = decoder(data["nonce"])
@@ -120,7 +145,9 @@ def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: J
     try:
         plaintext = decryptor(key, ciphertext, tag, nonce)
         return plaintext.decode("utf-8")
-    except ValueError as e:
+    except InvalidKeySize as e:
+        raise e
+    except Exception as e:
         raise DecryptionKeyError from e
 
 
@@ -148,6 +175,8 @@ def encrypt_bin(key: Union[str, bytes], data: Union[str, bytes], cipher: BinaryC
     encryptor = encrypt_AES_GCM_128 if cipher == BinaryCiphers.BINARY_AES_GCM_128 else encrypt_ChaCha20_Poly1305
     try:
         ciphertext, tag, nonce = encryptor(key, data)
+    except InvalidKeySize as e:
+        raise e
     except Exception as e:
         raise EncryptionKeyError from e
 
@@ -175,14 +204,20 @@ def decrypt_bin(key: Union[str, bytes], ciphertext: bytes, cipher: BinaryCiphers
 
     # extract nonce/tag depending on cipher, sizes are different
     if cipher == BinaryCiphers.BINARY_AES_GCM_128:
-        nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+        nonce, ciphertext, tag = (ciphertext[:AES_GCM_NONCE_SIZE],
+                                  ciphertext[AES_GCM_NONCE_SIZE:-AES_GCM_TAG_SIZE],
+                                  ciphertext[-AES_GCM_TAG_SIZE:])
     else:
-        nonce, ciphertext, tag = ciphertext[:12], ciphertext[12:-16], ciphertext[-16:]
+        nonce, ciphertext, tag = (ciphertext[:CHACHA20_NONCE_SIZE],
+                                  ciphertext[CHACHA20_NONCE_SIZE:-CHACHA20_TAG_SIZE],
+                                  ciphertext[-CHACHA20_TAG_SIZE:])
 
     decryptor = decrypt_AES_GCM_128 if cipher == BinaryCiphers.BINARY_AES_GCM_128 else decrypt_ChaCha20_Poly1305
     try:
         return decryptor(key, ciphertext, tag, nonce)
-    except ValueError as e:
+    except InvalidKeySize as e:
+        raise e
+    except Exception as e:
         raise DecryptionKeyError from e
 
 
@@ -205,8 +240,8 @@ def encrypt_AES_GCM_128(key: Union[str, bytes], text: Union[str, bytes],
         text = bytes(text, encoding="utf-8")
     if not isinstance(key, bytes):
         key = bytes(key, encoding="utf-8")
-    if len(key) != 16:  # AES-128 uses 128 bit/16 byte keys
-        raise ValueError("AES-GCM-128 requires a 16-byte key")
+    if len(key) != AES_GCM_KEY_SIZE:  # AES-128 uses 128 bit/16 byte keys
+        raise InvalidKeySize("AES-GCM-128 requires a 16-byte key")
     cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
     ciphertext, tag = cipher.encrypt_and_digest(text)
     return ciphertext, tag, cipher.nonce
@@ -226,10 +261,13 @@ def decrypt_AES_GCM_128(key: Union[str, bytes], ciphertext: bytes, tag: bytes, n
         str: The decrypted plaintext.
 
     Raises:
+        InvalidKeySize: If key size is not valid
         ValueError: If decryption or authentication fails.
     """
-    if not isinstance(key, bytes):
-        key = bytes(key, encoding="utf-8")
+    if isinstance(key, str):
+        key = key.encode("utf-8")
+    if len(key) != AES_GCM_KEY_SIZE:  # AES-128 uses 128 bit/16 byte keys
+        raise InvalidKeySize("AES-GCM-128 requires a 16-byte key")
     cipher = AES.new(key, AES.MODE_GCM, nonce)
     return cipher.decrypt_and_verify(ciphertext, tag)
 
@@ -248,13 +286,16 @@ def encrypt_ChaCha20_Poly1305(key: Union[str, bytes],
     Returns:
         tuple[bytes, bytes, bytes]: The ciphertext, authentication tag, and nonce.
     """
-    if not isinstance(text, bytes):
-        text = bytes(text, encoding="utf-8")
-    if not isinstance(key, bytes):
-        key = bytes(key, encoding="utf-8")
-    assert len(key) == 32  # ChaCha20 uses 256 bit/32 byte keys
+    if isinstance(text, str):
+        text = text.encode("utf-8")
+    if isinstance(key, str):
+        key = key.encode("utf-8")
+
+    if len(key) != CHACHA20_KEY_SIZE:  # ChaCha20 uses 256 bit/32 byte keys
+        raise InvalidKeySize("CHACHA20-POLY1305 requires a 32-byte key")
     if nonce:
-        assert len(nonce) == 12  # 92bits/12bytes bytes per RFC7539
+        if len(nonce) != CHACHA20_NONCE_SIZE:  # 92bits/12bytes per RFC7539
+            raise InvalidKeySize("CHACHA20-POLY1305 requires a 12-byte nonce per RFC7539")
     cipher = ChaCha20_Poly1305.new(key=key, nonce=nonce)
     ciphertext, tag = cipher.encrypt_and_digest(text)
     return ciphertext, tag, cipher.nonce
@@ -277,14 +318,17 @@ def decrypt_ChaCha20_Poly1305(key: Union[str, bytes],
         str: The decrypted plaintext.
 
     Raises:
+        InvalidKeySize:
         ValueError: If decryption or authentication fails.
     """
-    if not isinstance(key, bytes):
-        key = bytes(key, encoding="utf-8")
+    if isinstance(key, str):
+        key = key.encode("utf-8")
 
-    assert len(key) == 32  # ChaCha20 uses 256 bit/32 byte keys
+    if len(key) != CHACHA20_KEY_SIZE:  # ChaCha20 uses 256 bit/32 byte keys
+        raise InvalidKeySize("CHACHA20-POLY1305 requires a 32-byte key")
     if nonce:
-        assert len(nonce) == 12  # 92bits/12bytes per RFC7539
+        if len(nonce) != CHACHA20_NONCE_SIZE:  # 92bits/12bytes per RFC7539
+            raise InvalidKeySize("CHACHA20-POLY1305 requires a 12-byte nonce per RFC7539")
     cipher = ChaCha20_Poly1305.new(key=key, nonce=nonce)
     return cipher.decrypt_and_verify(ciphertext, tag)
 
@@ -294,7 +338,7 @@ if __name__ == "__main__":
 
     print("JSON-B64-AES-GCM-128" == JsonCiphers.JSON_B64_AES_GCM_128)
 
-    key = get_random_bytes(32)
+    key = get_random_bytes(CHACHA20_KEY_SIZE)
     plaintext = b'Attack at dawn'
     ciphertext, tag, nonce = encrypt_ChaCha20_Poly1305(key, plaintext)
     recovered = decrypt_ChaCha20_Poly1305(key, ciphertext, tag, nonce)

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -68,8 +68,11 @@ def encrypt_as_json(key: Union[str, bytes], data: Union[str, Dict[str, Any]],
 
     ciphertext = encrypt_bin(key, data, cipher=bcipher)
 
-    # TODO - adjust depending on cipher, sizes are different
-    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+    # extract nonce/tag depending on cipher, sizes are different
+    if cipher in aes_ciphers:
+        nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+    else:
+        nonce, ciphertext, tag = ciphertext[:12], ciphertext[12:-16], ciphertext[-16:]
 
     encoder = pybase64.b64encode if cipher in b64_ciphers else hexlify
 
@@ -108,7 +111,6 @@ def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: J
 
     ciphertext = decoder(data["ciphertext"])
     if "tag" not in data:  # web crypto compatibility
-        # TODO - adjust depending on cipher, sizes are different
         ciphertext, tag = ciphertext[:-16], ciphertext[-16:]
     else:
         tag = decoder(data["tag"])
@@ -169,8 +171,11 @@ def decrypt_bin(key: Union[str, bytes], ciphertext: bytes, cipher: BinaryCiphers
     if cipher not in BinaryCiphers:
         raise InvalidCipher(f"Invalid binary cipher: {str(cipher)}")
 
-    # TODO - adjust depending on cipher, sizes are different
-    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+    # extract nonce/tag depending on cipher, sizes are different
+    if cipher == BinaryCiphers.BINARY_AES_GCM_128:
+        nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+    else:
+        nonce, ciphertext, tag = ciphertext[:12], ciphertext[12:-16], ciphertext[-16:]
 
     decryptor = decrypt_AES_GCM_128 if cipher == BinaryCiphers.BINARY_AES_GCM_128 else decrypt_ChaCha20_Poly1305
     try:

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -1,0 +1,298 @@
+import enum
+import json
+from binascii import hexlify, unhexlify
+from typing import Union, Optional, Dict, Any
+
+import pybase64
+from Cryptodome.Cipher import AES, ChaCha20_Poly1305
+
+from hivemind_bus_client.exceptions import EncryptionKeyError, DecryptionKeyError, InvalidCipher
+
+
+class JsonCiphers(str, enum.Enum):
+    """
+    Enum representing JSON-based encryption ciphers.
+    """
+    JSON_B64_AES_GCM_128 = "JSON-B64-AES-GCM-128"  # JSON text output with Base64 encoding
+    JSON_HEX_AES_GCM_128 = "JSON-HEX-AES-GCM-128"  # JSON text output with Hex encoding
+    JSON_B64_CHACHA20_POLY1305 = "JSON-B64-CHACHA20-POLY1305"  # JSON text output with Base64 encoding
+    JSON_HEX_CHACHA20_POLY1305 = "JSON-HEX-CHACHA20-POLY1305"  # JSON text output with Hex encoding
+
+
+class BinaryCiphers(str, enum.Enum):
+    """
+    Enum representing binary encryption ciphers.
+
+    Specifications:
+      - AES - http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf
+      - GCM - http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+      - CHACHA20-POLY1305 - https://datatracker.ietf.org/doc/html/rfc7539
+    """
+    BINARY_AES_GCM_128 = "BINARY-AES-GCM-128"  # Binary output
+    BINARY_CHACHA20_POLY1305 = "BINARY-CHACHA20-POLY1305"  # specified in RFC7539.
+
+
+class TextCiphers(str, enum.Enum):
+    """
+    Enum representing text-based encryption ciphers.
+    """
+    B64_AES_GCM_128 = "B64-AES-GCM-128"  # Text output with Base64 encoding
+    HEX_AES_GCM_128 = "HEX-AES-GCM-128"  # Text output with Hex encoding
+    B64_CHACHA20_POLY1305 = "B64-CHACHA20-POLY1305"  # Text output with Base64 encoding
+    HEX_CHACHA20_POLY1305 = "HEX-CHACHA20-POLY1305"  # Text output with Hex encoding
+
+
+def encrypt_as_json(key: Union[str, bytes], data: Union[str, Dict[str, Any]],
+                    cipher: JsonCiphers = JsonCiphers.JSON_B64_AES_GCM_128) -> str:
+    """
+    Encrypts the given data and outputs it as a JSON string.
+
+    Args:
+        key (Union[str, bytes]): The encryption key, up to 16 bytes. Longer keys will be truncated.
+        data (Union[str, Dict[str, Any]]): The data to encrypt. If a dictionary, it will be serialized to JSON.
+        cipher (JsonCiphers): The encryption cipher. Supported options:
+            - JSON-B64-AES-GCM-128: Outputs Base64-encoded JSON.
+            - JSON-HEX-AES-GCM-128: Outputs Hex-encoded JSON.
+
+    Returns:
+        str: A JSON string containing the encrypted data, nonce, and tag.
+
+    Raises:
+        InvalidCipher: If an unsupported cipher is provided.
+    """
+    if cipher not in JsonCiphers:
+        raise InvalidCipher(f"Invalid JSON cipher: {str(cipher)}")
+
+    if isinstance(data, dict):
+        data = json.dumps(data)
+
+    aes_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_HEX_AES_GCM_128}
+    b64_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_B64_CHACHA20_POLY1305}
+
+    bcipher = BinaryCiphers.BINARY_AES_GCM_128 if cipher in aes_ciphers else BinaryCiphers.BINARY_CHACHA20_POLY1305
+
+    ciphertext = encrypt_bin(key, data, cipher=bcipher)
+
+    # TODO - adjust depending on cipher, sizes are different
+    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+
+    encoder = pybase64.b64encode if cipher in b64_ciphers else hexlify
+
+    return json.dumps({
+        "ciphertext": encoder(ciphertext).decode('utf-8'),
+        "tag": encoder(tag).decode('utf-8'),
+        "nonce": encoder(nonce).decode('utf-8')
+    })
+
+
+def decrypt_from_json(key: Union[str, bytes], data: Union[str, bytes], cipher: JsonCiphers) -> str:
+    """
+    Decrypts data from a JSON string.
+
+    Args:
+        key (Union[str, bytes]): The decryption key, up to 16 bytes. Longer keys will be truncated.
+        data (Union[str, bytes]): The encrypted data as a JSON string or bytes.
+        cipher (Optional[JsonCiphers]): The cipher used for encryption. If None, it is auto-detected.
+
+    Returns:
+        str: The decrypted plaintext data.
+
+    Raises:
+        InvalidCipher: If an unsupported cipher is provided.
+        DecryptionKeyError: If decryption fails due to an invalid key or corrupted data.
+    """
+
+    aes_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_HEX_AES_GCM_128}
+    b64_ciphers = {JsonCiphers.JSON_B64_AES_GCM_128, JsonCiphers.JSON_B64_CHACHA20_POLY1305}
+
+    if isinstance(data, str):
+        data = json.loads(data)
+
+    decoder = pybase64.b64decode if cipher in b64_ciphers else unhexlify
+    bcipher = BinaryCiphers.BINARY_AES_GCM_128 if cipher in aes_ciphers else BinaryCiphers.BINARY_CHACHA20_POLY1305
+
+    ciphertext = decoder(data["ciphertext"])
+    if "tag" not in data:  # web crypto compatibility
+        # TODO - adjust depending on cipher, sizes are different
+        ciphertext, tag = ciphertext[:-16], ciphertext[-16:]
+    else:
+        tag = decoder(data["tag"])
+    nonce = decoder(data["nonce"])
+
+    decryptor = decrypt_AES_GCM_128 if bcipher == BinaryCiphers.BINARY_AES_GCM_128 else decrypt_ChaCha20_Poly1305
+    try:
+        plaintext = decryptor(key, ciphertext, tag, nonce)
+        return plaintext.decode("utf-8")
+    except ValueError as e:
+        raise DecryptionKeyError from e
+
+
+def encrypt_bin(key: Union[str, bytes], data: Union[str, bytes], cipher: BinaryCiphers) -> bytes:
+    """
+    Encrypts the given data and returns it as binary.
+
+    Args:
+        key (Union[str, bytes]): The encryption key, up to 16 bytes. Longer keys will be truncated.
+        data (Union[str, bytes]): The data to encrypt. Strings will be encoded as UTF-8.
+        cipher (BinaryCiphers): The encryption cipher. Only BINARY_AES_GCM_128 is supported.
+
+    Returns:
+        bytes: The encrypted data, including the nonce and tag.
+
+    Raises:
+        InvalidCipher: If an unsupported cipher is provided.
+        EncryptionKeyError: If encryption fails.
+    """
+    if cipher not in BinaryCiphers:
+        raise InvalidCipher(f"Invalid binary cipher: {str(cipher)}")
+
+    encryptor = encrypt_AES_GCM_128 if cipher == BinaryCiphers.BINARY_AES_GCM_128 else encrypt_ChaCha20_Poly1305
+    try:
+        ciphertext, tag, nonce = encryptor(key, data)
+    except Exception as e:
+        raise EncryptionKeyError from e
+
+    return nonce + ciphertext + tag
+
+
+def decrypt_bin(key: Union[str, bytes], ciphertext: bytes, cipher: BinaryCiphers) -> bytes:
+    """
+    Decrypts binary data.
+
+    Args:
+        key (Union[str, bytes]): The decryption key, up to 16 bytes. Longer keys will be truncated.
+        ciphertext (bytes): The binary encrypted data. Must include nonce and tag.
+        cipher (BinaryCiphers): The cipher used for encryption. Only BINARY_AES_GCM_128 is supported.
+
+    Returns:
+        bytes: The decrypted plaintext data.
+
+    Raises:
+        InvalidCipher: If an unsupported cipher is provided.
+        DecryptionKeyError: If decryption fails due to an invalid key or corrupted data.
+    """
+    if cipher not in BinaryCiphers:
+        raise InvalidCipher(f"Invalid binary cipher: {str(cipher)}")
+
+    # TODO - adjust depending on cipher, sizes are different
+    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
+
+    decryptor = decrypt_AES_GCM_128 if cipher == BinaryCiphers.BINARY_AES_GCM_128 else decrypt_ChaCha20_Poly1305
+    try:
+        return decryptor(key, ciphertext, tag, nonce)
+    except ValueError as e:
+        raise DecryptionKeyError from e
+
+
+#############################
+# Cipher Implementations
+def encrypt_AES_GCM_128(key: Union[str, bytes], text: Union[str, bytes],
+                        nonce: Optional[bytes] = None) -> tuple[bytes, bytes, bytes]:
+    """
+    Encrypts plaintext using AES-GCM-128.
+
+    Args:
+        key (Union[str, bytes]): The encryption key. Strings will be encoded as UTF-8.
+        text (Union[str, bytes]): The plaintext to encrypt.
+        nonce (Optional[bytes]): An optional nonce. If None, a new one is generated.
+
+    Returns:
+        tuple[bytes, bytes, bytes]: The ciphertext, authentication tag, and nonce.
+    """
+    if not isinstance(text, bytes):
+        text = bytes(text, encoding="utf-8")
+    if not isinstance(key, bytes):
+        key = bytes(key, encoding="utf-8")
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(text)
+    return ciphertext, tag, cipher.nonce
+
+
+def decrypt_AES_GCM_128(key: Union[str, bytes], ciphertext: bytes, tag: bytes, nonce: bytes) -> bytes:
+    """
+    Decrypts ciphertext encrypted using AES-GCM-128.
+
+    Args:
+        key (Union[str, bytes]): The decryption key. Strings will be encoded as UTF-8.
+        ciphertext (bytes): The encrypted ciphertext.
+        tag (bytes): The authentication tag.
+        nonce (bytes): The nonce used during encryption.
+
+    Returns:
+        str: The decrypted plaintext.
+
+    Raises:
+        ValueError: If decryption or authentication fails.
+    """
+    if not isinstance(key, bytes):
+        key = bytes(key, encoding="utf-8")
+    cipher = AES.new(key, AES.MODE_GCM, nonce)
+    return cipher.decrypt_and_verify(ciphertext, tag)
+
+
+def encrypt_ChaCha20_Poly1305(key: Union[str, bytes],
+                              text: Union[str, bytes],
+                              nonce: Optional[bytes] = None) -> tuple[bytes, bytes, bytes]:
+    """
+    Encrypts plaintext using AES-GCM-128.
+
+    Args:
+        key (Union[str, bytes]): The encryption key. Strings will be encoded as UTF-8.
+        text (Union[str, bytes]): The plaintext to encrypt.
+        nonce (Optional[bytes]): An optional nonce. If None, a new one is generated.
+
+    Returns:
+        tuple[bytes, bytes, bytes]: The ciphertext, authentication tag, and nonce.
+    """
+    if not isinstance(text, bytes):
+        text = bytes(text, encoding="utf-8")
+    if not isinstance(key, bytes):
+        key = bytes(key, encoding="utf-8")
+    assert len(key) == 32  # ChaCha20 uses 256 bit/32 byte keys
+    if nonce:
+        assert len(nonce) == 12  # 92bits/12bytes bytes per RFC7539
+    cipher = ChaCha20_Poly1305.new(key=key, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(text)
+    return ciphertext, tag, cipher.nonce
+
+
+def decrypt_ChaCha20_Poly1305(key: Union[str, bytes],
+                              ciphertext: bytes,
+                              tag: bytes,
+                              nonce: bytes) -> bytes:
+    """
+    Decrypts ciphertext encrypted using AES-GCM-128.
+
+    Args:
+        key (Union[str, bytes]): The decryption key. Strings will be encoded as UTF-8.
+        ciphertext (bytes): The encrypted ciphertext.
+        tag (bytes): The authentication tag.
+        nonce (bytes): The nonce used during encryption.
+
+    Returns:
+        str: The decrypted plaintext.
+
+    Raises:
+        ValueError: If decryption or authentication fails.
+    """
+    if not isinstance(key, bytes):
+        key = bytes(key, encoding="utf-8")
+
+    assert len(key) == 32  # ChaCha20 uses 256 bit/32 byte keys
+    if nonce:
+        assert len(nonce) == 12  # 92bits/12bytes per RFC7539
+    cipher = ChaCha20_Poly1305.new(key=key, nonce=nonce)
+    return cipher.decrypt_and_verify(ciphertext, tag)
+
+
+if __name__ == "__main__":
+    from Cryptodome.Random import get_random_bytes
+
+    print("JSON-B64-AES-GCM-128" == JsonCiphers.JSON_B64_AES_GCM_128)
+
+    key = get_random_bytes(32)
+    plaintext = b'Attack at dawn'
+    ciphertext, tag, nonce = encrypt_ChaCha20_Poly1305(key, plaintext)
+    recovered = decrypt_ChaCha20_Poly1305(key, ciphertext, tag, nonce)
+    print(recovered)
+    assert recovered == plaintext

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -37,16 +37,6 @@ class BinaryCiphers(str, enum.Enum):
     BINARY_CHACHA20_POLY1305 = "BINARY-CHACHA20-POLY1305"  # specified in RFC7539.
 
 
-class TextCiphers(str, enum.Enum):
-    """
-    Enum representing text-based encryption ciphers.
-    """
-    B64_AES_GCM_128 = "B64-AES-GCM-128"  # Text output with Base64 encoding
-    HEX_AES_GCM_128 = "HEX-AES-GCM-128"  # Text output with Hex encoding
-    B64_CHACHA20_POLY1305 = "B64-CHACHA20-POLY1305"  # Text output with Base64 encoding
-    HEX_CHACHA20_POLY1305 = "HEX-CHACHA20-POLY1305"  # Text output with Hex encoding
-
-
 def encrypt_as_json(key: Union[str, bytes], data: Union[str, Dict[str, Any]],
                     cipher: JsonCiphers = JsonCiphers.JSON_B64_AES_GCM_128) -> str:
     """

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -6,7 +6,12 @@ from typing import Union, Optional, Dict, Any
 import pybase64
 from Cryptodome.Cipher import AES, ChaCha20_Poly1305
 
+from cpuinfo import get_cpu_info
 from hivemind_bus_client.exceptions import EncryptionKeyError, DecryptionKeyError, InvalidCipher
+
+
+def cpu_supports_AES() -> bool:
+    return "aes" in get_cpu_info()["flags"]
 
 
 class JsonCiphers(str, enum.Enum):

--- a/hivemind_bus_client/encryption.py
+++ b/hivemind_bus_client/encryption.py
@@ -131,7 +131,9 @@ def encrypt_bin(key: Union[str, bytes], data: Union[str, bytes], cipher: BinaryC
     Args:
         key (Union[str, bytes]): The encryption key, up to 16 bytes. Longer keys will be truncated.
         data (Union[str, bytes]): The data to encrypt. Strings will be encoded as UTF-8.
-        cipher (BinaryCiphers): The encryption cipher. Only BINARY_AES_GCM_128 is supported.
+        cipher (BinaryCiphers): The encryption cipher. Supported options:
+            - BINARY_AES_GCM_128: AES-GCM with 128-bit key
+            - BINARY_CHACHA20_POLY1305: ChaCha20-Poly1305 with 256-bit key
 
     Returns:
         bytes: The encrypted data, including the nonce and tag.
@@ -203,6 +205,8 @@ def encrypt_AES_GCM_128(key: Union[str, bytes], text: Union[str, bytes],
         text = bytes(text, encoding="utf-8")
     if not isinstance(key, bytes):
         key = bytes(key, encoding="utf-8")
+    if len(key) != 16:  # AES-128 uses 128 bit/16 byte keys
+        raise ValueError("AES-GCM-128 requires a 16-byte key")
     cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
     ciphertext, tag = cipher.encrypt_and_digest(text)
     return ciphertext, tag, cipher.nonce
@@ -234,7 +238,7 @@ def encrypt_ChaCha20_Poly1305(key: Union[str, bytes],
                               text: Union[str, bytes],
                               nonce: Optional[bytes] = None) -> tuple[bytes, bytes, bytes]:
     """
-    Encrypts plaintext using AES-GCM-128.
+    Encrypts plaintext using ChaCha20-Poly1305.
 
     Args:
         key (Union[str, bytes]): The encryption key. Strings will be encoded as UTF-8.

--- a/hivemind_bus_client/exceptions.py
+++ b/hivemind_bus_client/exceptions.py
@@ -45,3 +45,8 @@ class SecureConnectionFailed(HiveMindConnectionError):
 
 class HiveMindEntryPointNotFound(HiveMindConnectionError):
     """ can not connect to provided address """
+
+
+class Z85DecodeError(Exception):
+    """Exception raised for errors in decoding Z85b."""
+    pass

--- a/hivemind_bus_client/exceptions.py
+++ b/hivemind_bus_client/exceptions.py
@@ -15,6 +15,10 @@ class InvalidCipher(HiveMindException):
     """unknown encryption scheme requested"""
 
 
+class InvalidKeySize(HiveMindException):
+    """ Encryption Key size does not obey specification"""
+
+
 class WrongEncryptionKey(HiveMindException):
     """ Wrong Encryption Key"""
 

--- a/hivemind_bus_client/exceptions.py
+++ b/hivemind_bus_client/exceptions.py
@@ -15,6 +15,10 @@ class InvalidCipher(HiveMindException):
     """unknown encryption scheme requested"""
 
 
+class InvalidEncoding(HiveMindException):
+    """unknown encoding scheme requested"""
+
+
 class InvalidKeySize(HiveMindException):
     """ Encryption Key size does not obey specification"""
 

--- a/hivemind_bus_client/exceptions.py
+++ b/hivemind_bus_client/exceptions.py
@@ -11,6 +11,10 @@ class UnauthorizedKeyError(HiveMindException):
     """ Invalid Key provided """
 
 
+class InvalidCipher(HiveMindException):
+    """unknown encryption scheme requested"""
+
+
 class WrongEncryptionKey(HiveMindException):
     """ Wrong Encryption Key"""
 

--- a/hivemind_bus_client/message.py
+++ b/hivemind_bus_client/message.py
@@ -163,7 +163,7 @@ class HiveMessage:
 
     @property
     def as_json(self) -> str:
-        return json.dumps(self.as_dict)
+        return json.dumps(self.as_dict, ensure_ascii=False)
 
     def serialize(self) -> str:
         return self.as_json

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -9,7 +9,7 @@ from ovos_bus_client.session import Session, SessionManager
 from ovos_utils.log import LOG
 
 from hivemind_bus_client.client import HiveMessageBusClient
-from hivemind_bus_client.encryption import JsonCiphers, BinaryCiphers, cpu_supports_AES
+from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from poorman_handshake import HandShake, PasswordHandShake
@@ -119,17 +119,6 @@ class HiveMindSlaveProtocol:
         # this is how ovos-core bus refers to this slave's master
         return self.internal_protocol.node_id
 
-    @property
-    def optimal_ciphers(self) -> Tuple[JsonCiphers, BinaryCiphers]:
-        if not cpu_supports_AES():
-            j = JsonCiphers.JSON_B64_CHACHA20_POLY1305
-            b = BinaryCiphers.BINARY_CHACHA20_POLY1305
-        else:
-            j = JsonCiphers.JSON_B64_AES_GCM_128
-            b = BinaryCiphers.BINARY_AES_GCM_128
-        return j, b
-
-    # TODO - handshake handlers
     # hivemind events
     def handle_illegal_msg(self, message: HiveMessage):
         # this should not happen,
@@ -155,8 +144,8 @@ class HiveMindSlaveProtocol:
             LOG.info("hivemind does not support binarization protocol")
 
         payload = {"binarize": self.binarize,
-                   "json_ciphers": list(c for c in JsonCiphers),
-                   "binary_ciphers": list(c for c in BinaryCiphers)}
+                   "encodings": list(c for c in SupportedEncodings),
+                   "ciphers": list(c for c in SupportedCiphers)}
         if self.pswd_handshake is not None:
             payload["envelope"] = self.pswd_handshake.generate_handshake()
         else:
@@ -194,10 +183,12 @@ class HiveMindSlaveProtocol:
         # master is performing the handshake
         if "envelope" in message.payload:
             envelope = message.payload["envelope"]
-            self.hm.json_cipher =  message.payload.get("json_cipher") or JsonCiphers.JSON_HEX_AES_GCM_128
-            self.hm.bin_cipher =  message.payload.get("binary_cipher") or BinaryCiphers.BINARY_AES_GCM_128
-            LOG.debug(f"Cipher to use: {self.hm.json_cipher} + {self.hm.bin_cipher}")
+            self.hm.json_encoding = message.payload.get("json_cipher") or SupportedEncodings.JSON_HEX
+            self.hm.cipher = message.payload.get("binary_cipher") or SupportedCiphers.AES_GCM
             self.receive_handshake(envelope)
+            LOG.debug(f"Encoding: {self.hm.json_encoding}")
+            LOG.debug(f"Cipher: {self.hm.cipher}")
+            LOG.debug(f"Key size: {len(self.pswd_handshake.secret) * 8}bit")
 
         # master is requesting handshake start
         else:
@@ -212,7 +203,7 @@ class HiveMindSlaveProtocol:
                 # TODO - flag to give preference to pre-shared key over handshake
 
             self.binarize = message.payload.get("binarize", False)
-            # TODO - flag to give preference to / require password or not
+            # TODO - flag to give preference to / require password or use RSA handshake
             # currently if password is set then it is always used
             if message.payload.get("password") and self.identity.password:
                 self.pswd_handshake = PasswordHandShake(self.identity.password)

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -145,6 +145,7 @@ class HiveMindSlaveProtocol:
 
         payload = {"binarize": self.binarize,
                    "encodings": [SupportedEncodings.JSON_B64,
+                                 SupportedEncodings.JSON_Z85B,
                                  SupportedEncodings.JSON_HEX],
                    "ciphers": optimal_ciphers()}
         if self.pswd_handshake is not None:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -9,7 +9,7 @@ from ovos_bus_client.session import Session, SessionManager
 from ovos_utils.log import LOG
 
 from hivemind_bus_client.client import HiveMessageBusClient
-from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers
+from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers, optimal_ciphers
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from poorman_handshake import HandShake, PasswordHandShake
@@ -144,8 +144,9 @@ class HiveMindSlaveProtocol:
             LOG.info("hivemind does not support binarization protocol")
 
         payload = {"binarize": self.binarize,
-                   "encodings": list(c for c in SupportedEncodings),
-                   "ciphers": list(c for c in SupportedCiphers)}
+                   "encodings": [SupportedEncodings.JSON_B64,
+                                 SupportedEncodings.JSON_HEX],
+                   "ciphers": optimal_ciphers()}
         if self.pswd_handshake is not None:
             payload["envelope"] = self.pswd_handshake.generate_handshake()
         else:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -184,8 +184,8 @@ class HiveMindSlaveProtocol:
         # master is performing the handshake
         if "envelope" in message.payload:
             envelope = message.payload["envelope"]
-            self.hm.json_encoding = message.payload.get("json_cipher") or SupportedEncodings.JSON_HEX
-            self.hm.cipher = message.payload.get("binary_cipher") or SupportedCiphers.AES_GCM
+            self.hm.json_encoding = message.payload.get("encoding") or SupportedEncodings.JSON_HEX
+            self.hm.cipher = message.payload.get("cipher") or SupportedCiphers.AES_GCM
             self.receive_handshake(envelope)
             LOG.debug(f"Encoding: {self.hm.json_encoding}")
             LOG.debug(f"Cipher: {self.hm.cipher}")
@@ -198,6 +198,10 @@ class HiveMindSlaveProtocol:
             #    self.hm.handshake_event.set()  # don't wait
             #    return
 
+            encodings = message.payload.get("encodings") or [SupportedEncodings.JSON_HEX]
+            ciphers = message.payload.get("ciphers") or [SupportedCiphers.AES_GCM]
+            LOG.debug(f"Server supported encodings: {encodings}")
+            LOG.debug(f"Server supported ciphers: {ciphers}")
             if message.payload.get("crypto_key") and self.hm.crypto_key:
                 pass
                 # we can use the pre-shared key instead of handshake

--- a/hivemind_bus_client/scripts.py
+++ b/hivemind_bus_client/scripts.py
@@ -198,8 +198,8 @@ def test_identity():
     node.close()
 
 
-@hmclient_cmds.command(help="recreate the PGP key for inter-node communication", name="reset-pgp")
-def reset_pgp_key():
+@hmclient_cmds.command(help="recreate the private RSA key for inter-node communication", name="reset-pgp")
+def reset_keys():
     identity = NodeIdentity()
     identity.create_keys()
     print("PUBKEY:", identity.public_key)

--- a/hivemind_bus_client/util.py
+++ b/hivemind_bus_client/util.py
@@ -2,6 +2,7 @@ import json
 import zlib
 from typing import Union, Dict
 
+from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers
 from hivemind_bus_client.message import HiveMessage, HiveMessageType, Message
 
 
@@ -140,9 +141,9 @@ def encrypt_as_json(key, data, b64=False) -> str:
         DeprecationWarning,
         stacklevel=2
     )
-    from hivemind_bus_client.encryption import encrypt_as_json as _ej, JsonCiphers
-    c = JsonCiphers.JSON_B64_AES_GCM_128 if b64 else JsonCiphers.JSON_HEX_AES_GCM_128
-    return _ej(key, data, c)
+    from hivemind_bus_client.encryption import encrypt_as_json as _ej
+    c = SupportedEncodings.JSON_B64 if b64 else SupportedEncodings.JSON_HEX
+    return _ej(key, data, encoding=c, cipher=SupportedCiphers.AES_GCM)
 
 
 def decrypt_from_json(key, data: Union[str, bytes]):
@@ -152,12 +153,12 @@ def decrypt_from_json(key, data: Union[str, bytes]):
         DeprecationWarning,
         stacklevel=2
     )
-    from hivemind_bus_client.encryption import decrypt_from_json as _dj, JsonCiphers
+    from hivemind_bus_client.encryption import decrypt_from_json as _dj
     try:
-        return _dj(key, data, JsonCiphers.JSON_HEX_AES_GCM_128)
+        return _dj(key, data, encoding=SupportedEncodings.JSON_HEX, cipher=SupportedCiphers.AES_GCM)
     except Exception as e:
         try:
-            return _dj(key, data, JsonCiphers.JSON_B64_AES_GCM_128)
+            return _dj(key, data, encoding=SupportedEncodings.JSON_B64, cipher=SupportedCiphers.AES_GCM)
         except:
             raise e
 
@@ -169,8 +170,8 @@ def encrypt_bin(key, data: Union[str, bytes]):
         DeprecationWarning,
         stacklevel=2
     )
-    from hivemind_bus_client.encryption import encrypt_bin as _eb, BinaryCiphers
-    return _eb(key, data, BinaryCiphers.BINARY_AES_GCM_128)
+    from hivemind_bus_client.encryption import encrypt_bin as _eb
+    return _eb(key, data, cipher=SupportedCiphers.AES_GCM)
 
 
 def decrypt_bin(key, ciphertext: bytes):
@@ -180,8 +181,8 @@ def decrypt_bin(key, ciphertext: bytes):
         DeprecationWarning,
         stacklevel=2
     )
-    from hivemind_bus_client.encryption import decrypt_bin as _db, BinaryCiphers
-    return _db(key, ciphertext, BinaryCiphers.BINARY_AES_GCM_128)
+    from hivemind_bus_client.encryption import decrypt_bin as _db
+    return _db(key, ciphertext, SupportedCiphers.AES_GCM)
 
 
 if __name__ == "__main__":

--- a/hivemind_bus_client/util.py
+++ b/hivemind_bus_client/util.py
@@ -1,12 +1,7 @@
 import json
 import zlib
-from binascii import hexlify, unhexlify
 from typing import Union, Dict
 
-import pybase64
-from ovos_utils.security import encrypt, decrypt, AES
-
-from hivemind_bus_client.exceptions import EncryptionKeyError, DecryptionKeyError
 from hivemind_bus_client.message import HiveMessage, HiveMessageType, Message
 
 
@@ -102,87 +97,6 @@ def get_mycroft_msg(pload: Union[HiveMessage, str, Dict]) -> Message:
     return pload
 
 
-def encrypt_as_json(key, data, b64=False) -> str:
-    # TODO default b64 to True in a future release
-    #  we dont want clients to update before servers, otherwise servers won't be able to decode
-    #  after a reasonable time all servers should support decoding both schemes and the default can change
-    if isinstance(data, dict):
-        data = json.dumps(data)
-    if len(key) > 16:
-        key = key[0:16]
-    ciphertext = encrypt_bin(key, data)
-    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
-    if b64:
-        return json.dumps({"ciphertext": pybase64.b64encode(ciphertext).decode('utf-8'),
-                           "tag": pybase64.b64encode(tag).decode('utf-8'),
-                           "nonce": pybase64.b64encode(nonce).decode('utf-8')})
-    return json.dumps({"ciphertext": hexlify(ciphertext).decode('utf-8'),
-                       "tag": hexlify(tag).decode('utf-8'),
-                       "nonce": hexlify(nonce).decode('utf-8')})
-
-
-def decrypt_from_json(key, data: Union[str, bytes]):
-    if isinstance(data, str):
-        data = json.loads(data)
-    if len(key) > 16:
-        key = key[0:16]
-
-    # payloads can be either hex encoded (old style)
-    # or b64 encoded (new style)
-    def decode(b64=False):
-        if b64:
-            decoder = pybase64.b64decode
-        else:
-            decoder = unhexlify
-
-        ciphertext = decoder(data["ciphertext"])
-        if data.get("tag") is None:  # web crypto
-            ciphertext, tag = ciphertext[:-16], ciphertext[-16:]
-        else:
-            tag = decoder(data["tag"])
-        nonce = decoder(data["nonce"])
-        return ciphertext, tag, nonce
-
-    is_b64 = any(a.isupper() for a in str(data))  # if any letter is uppercase, it must be b64
-    ciphertext, tag, nonce = decode(is_b64)
-    try:
-        return decrypt(key, ciphertext, tag, nonce)
-    except ValueError as e:
-        if not is_b64:
-            try:  # maybe it was b64 after all? unlikely but....
-                ciphertext, tag, nonce = decode(b64=True)
-                return decrypt(key, ciphertext, tag, nonce)
-            except ValueError:
-                pass
-        raise DecryptionKeyError from e
-
-
-def encrypt_bin(key, data: Union[str, bytes]):
-    if len(key) > 16:
-        key = key[0:16]
-    try:
-        ciphertext, tag, nonce = encrypt(key, data)
-    except:
-        raise EncryptionKeyError
-
-    return nonce + ciphertext + tag
-
-
-def decrypt_bin(key, ciphertext: bytes):
-    if len(key) > 16:
-        key = key[0:16]
-
-    nonce, ciphertext, tag = ciphertext[:16], ciphertext[16:-16], ciphertext[-16:]
-
-    try:
-        if not isinstance(key, bytes):
-            key = bytes(key, encoding="utf-8")
-        cipher = AES.new(key, AES.MODE_GCM, nonce)
-        return cipher.decrypt_and_verify(ciphertext, tag)
-    except ValueError:
-        raise DecryptionKeyError
-
-
 def compress_payload(text: Union[str, bytes]) -> bytes:
     # Compressing text
     if isinstance(text, str):
@@ -192,14 +106,7 @@ def compress_payload(text: Union[str, bytes]) -> bytes:
     return zlib.compress(decompressed)
 
 
-def decompress_payload(compressed: Union[str, bytes]) -> bytes:
-    # Decompressing text
-    if isinstance(compressed, str): # we really should be getting bytes here and not a str
-        if any(a.isupper() for a in compressed):
-            decoder = pybase64.b64decode
-        else:  # assume hex
-            decoder = unhexlify
-        compressed = decoder(compressed)
+def decompress_payload(compressed: bytes) -> bytes:
     return zlib.decompress(compressed)
 
 
@@ -219,6 +126,62 @@ def bytes2str(payload: bytes, compressed=False) -> str:
         return decompress_payload(payload).decode("utf-8")
     else:
         return payload.decode("utf-8")
+
+
+###############
+# deprecated
+import warnings
+
+
+def encrypt_as_json(key, data, b64=False) -> str:
+    warnings.warn(
+        "encrypt_as_json is deprecated and will be removed in future versions. "
+        "Use 'from hivemind_bus_client.encryption import encrypt_as_json' instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    from hivemind_bus_client.encryption import encrypt_as_json as _ej, JsonCiphers
+    c = JsonCiphers.JSON_B64_AES_GCM_128 if b64 else JsonCiphers.JSON_HEX_AES_GCM_128
+    return _ej(key, data, c)
+
+
+def decrypt_from_json(key, data: Union[str, bytes]):
+    warnings.warn(
+        "decrypt_from_json is deprecated and will be removed in future versions. "
+        "Use 'from hivemind_bus_client.encryption import decrypt_from_json' instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    from hivemind_bus_client.encryption import decrypt_from_json as _dj, JsonCiphers
+    try:
+        return _dj(key, data, JsonCiphers.JSON_HEX_AES_GCM_128)
+    except Exception as e:
+        try:
+            return _dj(key, data, JsonCiphers.JSON_B64_AES_GCM_128)
+        except:
+            raise e
+
+
+def encrypt_bin(key, data: Union[str, bytes]):
+    warnings.warn(
+        "encrypt_bin is deprecated and will be removed in future versions. "
+        "Use 'from hivemind_bus_client.encryption import encrypt_bin' instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    from hivemind_bus_client.encryption import encrypt_bin as _eb, BinaryCiphers
+    return _eb(key, data, BinaryCiphers.BINARY_AES_GCM_128)
+
+
+def decrypt_bin(key, ciphertext: bytes):
+    warnings.warn(
+        "decrypt_bin is deprecated and will be removed in future versions. "
+        "Use 'from hivemind_bus_client.encryption import decrypt_bin' instead",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    from hivemind_bus_client.encryption import decrypt_bin as _db, BinaryCiphers
+    return _db(key, ciphertext, BinaryCiphers.BINARY_AES_GCM_128)
 
 
 if __name__ == "__main__":

--- a/hivemind_bus_client/z85b.py
+++ b/hivemind_bus_client/z85b.py
@@ -12,16 +12,11 @@ This file is a derivative work of z85.py from pyzmq.
 Copyright (c) 2013 Brian Granger, Min Ragan-Kelley
 Distributed under the terms of the New BSD License.
 """
-
-from typing import Union
 import re
 import struct
+from typing import Union
 
-
-
-class Z85DecodeError(Exception):
-    """Exception raised for errors in decoding Z85b."""
-    pass
+from hivemind_bus_client.exceptions import Z85DecodeError
 
 
 class Z85B:
@@ -37,7 +32,6 @@ class Z85B:
     # Padding lengths for encoding and decoding
     _E_PADDING = [0, 3, 2, 1]
     _D_PADDING = [0, 4, 3, 2, 1]
-
 
     @classmethod
     def encode(cls, rawbytes: Union[str, bytes]) -> bytes:

--- a/hivemind_bus_client/z85b.py
+++ b/hivemind_bus_client/z85b.py
@@ -1,0 +1,108 @@
+"""
+Python implementation of Z85b 85-bit encoding.
+
+Z85b is a variation of ZMQ RFC 32 Z85 85-bit encoding with the following differences:
+1. Little-endian encoding (to facilitate alignment with lower byte indices).
+2. No requirement for a multiple of 4/5 length.
+3. `decode_z85b()` eliminates whitespace from the input.
+4. `decode_z85b()` raises a clear exception if invalid characters are encountered.
+
+This file is a derivative work of z85.py from pyzmq.
+
+Copyright (c) 2013 Brian Granger, Min Ragan-Kelley
+Distributed under the terms of the New BSD License.
+"""
+
+from typing import Union
+import re
+import struct
+
+
+
+class Z85DecodeError(Exception):
+    """Exception raised for errors in decoding Z85b."""
+    pass
+
+
+class Z85B:
+    # Z85CHARS is the base 85 symbol table
+    Z85CHARS = bytearray(b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#")
+
+    # Z85MAP maps integers in [0, 84] to the appropriate character in Z85CHARS
+    Z85MAP = {char: idx for idx, char in enumerate(Z85CHARS)}
+
+    # Powers of 85 for encoding/decoding
+    _85s = [85 ** i for i in range(5)]
+
+    # Padding lengths for encoding and decoding
+    _E_PADDING = [0, 3, 2, 1]
+    _D_PADDING = [0, 4, 3, 2, 1]
+
+
+    @classmethod
+    def encode(cls, rawbytes: Union[str, bytes]) -> bytes:
+        """
+        Encode raw bytes into Z85b format.
+
+        Args:
+            rawbytes (Union[str, bytes]): Input data to encode.
+
+        Returns:
+            bytes: Z85b-encoded bytes.
+        """
+        rawbytes = bytearray(rawbytes) if isinstance(rawbytes, (bytes, str)) else rawbytes
+        padding = cls._E_PADDING[len(rawbytes) % 4]
+        rawbytes += b'\x00' * padding
+        nvalues = len(rawbytes) // 4
+
+        # Pack the raw bytes into little-endian 32-bit integers
+        values = struct.unpack(f'<{nvalues}I', rawbytes)
+        encoded = bytearray()
+
+        for value in values:
+            for offset in cls._85s:
+                encoded.append(cls.Z85CHARS[(value // offset) % 85])
+
+        # Remove padding characters from the encoded output
+        if padding:
+            encoded = encoded[:-padding]
+        return bytes(encoded)
+
+    @classmethod
+    def decode(cls, z85bytes: Union[str, bytes]) -> bytes:
+        """
+        Decode Z85b-encoded bytes into raw bytes.
+
+        Args:
+            z85bytes (Union[str, bytes]): Z85b-encoded data.
+
+        Returns:
+            bytes: Decoded raw bytes.
+
+        Raises:
+            Z85DecodeError: If invalid characters are encountered during decoding.
+        """
+        # Normalize input by removing whitespace
+        z85bytes = bytearray(re.sub(rb'\s+', b'', z85bytes if isinstance(z85bytes, bytes) else z85bytes.encode()))
+        padding = cls._D_PADDING[len(z85bytes) % 5]
+        nvalues = (len(z85bytes) + padding) // 5
+
+        values = []
+        for i in range(0, len(z85bytes), 5):
+            value = 0
+            for j, offset in enumerate(cls._85s):
+                try:
+                    value += cls.Z85MAP[z85bytes[i + j]] * offset
+                except IndexError:
+                    break  # End of input reached
+                except KeyError as e:
+                    raise Z85DecodeError(f"Invalid byte code: {e.args[0]!r}")
+            values.append(value)
+
+        # Unpack the values back into raw bytes
+        decoded = struct.pack(f'<{nvalues}I', *values)
+
+        # Remove padding from the decoded output
+        if padding:
+            decoded = decoded[:-padding]
+        return decoded

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bitstring>=4.1.1
 cryptography>=41.0.1
 pycryptodomex>=3.18.0
 pybase64
+py-cpuinfo


### PR DESCRIPTION
configurable ciphers for encryption, reports available ones during handshake

adds ChaCha20 as an option

allows specifying b64/hex encoding during handshake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced encryption capabilities with configurable cipher options for JSON and binary data.
	- Added support for multiple encryption schemes (AES-GCM-128, ChaCha20-Poly1305).
	- Introduced new exception classes for unsupported ciphers, invalid encodings, and invalid key sizes.
	- Updated command for key management to reflect changes in key type.
	- Added a method to determine optimal cipher types based on CPU capabilities.
	- Implemented a new Z85b encoding class for improved data encoding.

- **Bug Fixes**
	- Improved error handling for encryption and decryption processes.

- **Documentation**
	- Added deprecation warnings for legacy encryption functions.

- **Refactor**
	- Restructured encryption and protocol handling to support more flexible message security.
	- Streamlined handshake process with enhanced cipher negotiation.
	- Updated function signatures to improve clarity and usability.

- **Chores**
	- Added new dependencies to the requirements file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->