### PR TITLE
feat: add flood-based PING network discovery and hive topology mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Options:
 
 Commands:
   escalate      escalate a single mycroft message
+  ping          send a PING and display the reachable hive map
   propagate     propagate a single mycroft message
   send-mycroft  send a single mycroft message
   terminal      simple cli interface to inject utterances and print speech

--- a/hivemind_bus_client/hive_map.py
+++ b/hivemind_bus_client/hive_map.py
@@ -1,0 +1,221 @@
+"""Hive topology mapper built from PING-only network discovery.
+
+Every node responds to a PING by propagating its own PING (with the same
+``flood_id``), so all nodes in the hive sync simultaneously.  An ephemeral
+``flood_id`` prevents infinite loops.
+"""
+import json
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set
+
+from hivemind_bus_client.message import HiveMessage
+
+
+@dataclass
+class NodeInfo:
+    """Metadata about a node discovered via PING flood."""
+
+    peer: str
+    site_id: Optional[str] = None
+    timestamp: Optional[float] = None       # sender's clock when they created the PING
+    received_at: Optional[float] = None     # our local clock when we received it
+
+    @property
+    def rtt_ms(self) -> Optional[float]:
+        """Round-trip time in milliseconds, or None if timestamps are unavailable."""
+        if self.received_at is not None and self.timestamp is not None:
+            return (self.received_at - self.timestamp) * 1000
+        return None
+
+
+class HiveMapper:
+    """Collect responsive PINGs from a flood and build a directed hive topology graph.
+
+    Usage::
+
+        mapper = HiveMapper()
+        mapper.start_ping(flood_id)
+        # ... feed each received inner PING HiveMessage ...
+        mapper.on_ping(ping_msg)
+        print(mapper.to_ascii(root_peer="my-node::session1"))
+    """
+
+    def __init__(self) -> None:
+        # peer → NodeInfo for every node that responded
+        self.nodes: Dict[str, NodeInfo] = {}
+        # source peer → set of target peers (directed edges from route records)
+        self.edges: Dict[str, Set[str]] = {}
+        # flood_id → set of peer IDs that already sent a PING (deduplication)
+        self._seen_pings: Dict[str, Set[str]] = {}
+
+    def start_ping(self, flood_id: str) -> None:
+        """Register a new PING session, clearing stale deduplication state for that ID.
+
+        Args:
+            flood_id: UUID string from the PING payload.
+        """
+        self._seen_pings[flood_id] = set()
+
+    def on_ping(self, message: HiveMessage, received_at: Optional[float] = None) -> bool:
+        """Ingest a received PING HiveMessage and update the topology graph.
+
+        The route on *message* must already contain the hop history transferred
+        from the outer PROPAGATE wrapper (done by ``_unpack_message`` in the server
+        protocol before this method is called).
+
+        Args:
+            message: Inner PING HiveMessage with ``msg_type == HiveMessageType.PING``.
+            received_at: Local clock timestamp when the PING was received.
+
+        Returns:
+            True if the PING was new and the graph was updated; False if duplicate.
+        """
+        payload = message.payload
+        if not isinstance(payload, dict):
+            return False
+
+        flood_id = payload.get("flood_id", "")
+        peer = payload.get("peer", "")
+
+        if not peer:
+            return False
+
+        seen = self._seen_pings.setdefault(flood_id, set())
+        if peer in seen:
+            return False
+        seen.add(peer)
+
+        self.nodes[peer] = NodeInfo(
+            peer=peer,
+            site_id=payload.get("site_id"),
+            timestamp=payload.get("timestamp"),
+            received_at=received_at,
+        )
+
+        for hop in message.route:
+            source = hop.get("source", "")
+            targets = hop.get("targets") or []
+            if source:
+                edge_set = self.edges.setdefault(source, set())
+                for t in targets:
+                    if t:
+                        edge_set.add(t)
+
+        return True
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable snapshot of the current topology.
+
+        Returns:
+            dict with keys ``nodes`` (list of node dicts) and ``edges``
+            (list of ``{source, target}`` dicts).
+        """
+        nodes = [
+            {
+                "peer": n.peer,
+                "site_id": n.site_id,
+                "timestamp": n.timestamp,
+                "rtt_ms": n.rtt_ms,
+            }
+            for n in self.nodes.values()
+        ]
+        edges = [
+            {"source": src, "target": tgt}
+            for src, targets in self.edges.items()
+            for tgt in targets
+        ]
+        return {"nodes": nodes, "edges": edges}
+
+    def to_json(self) -> str:
+        """Return ``to_dict()`` as a formatted JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def to_ascii(self, root_peer: Optional[str] = None) -> str:
+        """Render the hive topology as a human-readable ASCII tree.
+
+        PING routes flow *toward* the originator, so edges are stored as
+        ``relayer → originator``.  When ``root_peer`` (the local node / PING
+        originator) is supplied the edge direction is inverted for display so
+        that the tree reads top-down from the originator outward to leaf nodes.
+
+        Args:
+            root_peer: Peer ID of the local node, labeled ``[self]`` at the
+                tree root.  Omit to display the raw edge directions.
+
+        Returns:
+            Multi-line string representing the topology.
+        """
+        if not self.nodes and not self.edges:
+            return "[No nodes discovered]"
+
+        lines: List[str] = []
+
+        if root_peer is not None:
+            # Build display children as the *inverse* of stored edges:
+            # stored: relayer → originator  →  display: originator ← relayer
+            display_children: Dict[str, List[str]] = {}
+            for src, targets in self.edges.items():
+                for t in targets:
+                    display_children.setdefault(t, [])
+                    if src not in display_children[t]:
+                        display_children[t].append(src)
+
+            def _render_inv(peer: str, prefix: str, is_last: bool) -> None:
+                connector = "└── " if is_last else "├── "
+                node = self.nodes.get(peer)
+                site = f"  site={node.site_id}" if node and node.site_id else ""
+                rtt = (f"  rtt={node.rtt_ms:.0f}ms"
+                       if node and node.rtt_ms is not None else "")
+                lines.append(f"{prefix}{connector}{peer}{site}{rtt}")
+                kids = display_children.get(peer, [])
+                child_prefix = prefix + ("    " if is_last else "│   ")
+                for i, kid in enumerate(kids):
+                    _render_inv(kid, child_prefix, i == len(kids) - 1)
+
+            node = self.nodes.get(root_peer)
+            site = f"  site={node.site_id}" if node and node.site_id else ""
+            lines.append(f"[self] {root_peer}{site}")
+            kids = display_children.get(root_peer, [])
+            for i, kid in enumerate(kids):
+                _render_inv(kid, "", i == len(kids) - 1)
+
+        else:
+            # Raw display following stored edge direction (relayer → originator)
+            children: Dict[str, List[str]] = {}
+            all_targets: Set[str] = set()
+            for src, targets in self.edges.items():
+                children.setdefault(src, [])
+                for t in targets:
+                    children[src].append(t)
+                    all_targets.add(t)
+
+            candidate_roots = [p for p in self.edges if p not in all_targets]
+            display_roots = candidate_roots or list(self.edges.keys())[:1]
+
+            def _render(peer: str, prefix: str, is_last: bool) -> None:
+                connector = "└── " if is_last else "├── "
+                node = self.nodes.get(peer)
+                site = f"  site={node.site_id}" if node and node.site_id else ""
+                rtt = (f"  rtt={node.rtt_ms:.0f}ms"
+                       if node and node.rtt_ms is not None else "")
+                lines.append(f"{prefix}{connector}{peer}{site}{rtt}")
+                kids = children.get(peer, [])
+                child_prefix = prefix + ("    " if is_last else "│   ")
+                for i, kid in enumerate(kids):
+                    _render(kid, child_prefix, i == len(kids) - 1)
+
+            for root in display_roots:
+                node = self.nodes.get(root)
+                site = f"  site={node.site_id}" if node and node.site_id else ""
+                lines.append(f"{root}{site}")
+                kids = children.get(root, [])
+                for i, kid in enumerate(kids):
+                    _render(kid, "", i == len(kids) - 1)
+
+        return "\n".join(lines) if lines else "[No topology data]"
+
+    def clear(self) -> None:
+        """Reset the mapper to an empty state."""
+        self.nodes.clear()
+        self.edges.clear()
+        self._seen_pings.clear()

--- a/hivemind_bus_client/hive_map.py
+++ b/hivemind_bus_client/hive_map.py
@@ -21,8 +21,13 @@ class NodeInfo:
     received_at: Optional[float] = None     # our local clock when we received it
 
     @property
-    def rtt_ms(self) -> Optional[float]:
-        """Round-trip time in milliseconds, or None if timestamps are unavailable."""
+    def latency_ms(self) -> Optional[float]:
+        """Estimated one-way latency in milliseconds (receiver clock minus sender clock).
+
+        This is a clock-difference estimate, **not** a true round-trip
+        measurement.  On unsynchronised clocks it may be negative or
+        inaccurate.  Returns None if either timestamp is unavailable.
+        """
         if self.received_at is not None and self.timestamp is not None:
             return (self.received_at - self.timestamp) * 1000
         return None
@@ -77,7 +82,7 @@ class HiveMapper:
         flood_id = payload.get("flood_id", "")
         peer = payload.get("peer", "")
 
-        if not peer:
+        if not flood_id or not peer:
             return False
 
         seen = self._seen_pings.setdefault(flood_id, set())
@@ -93,6 +98,8 @@ class HiveMapper:
         )
 
         for hop in message.route:
+            if not isinstance(hop, dict):
+                continue
             source = hop.get("source", "")
             targets = hop.get("targets") or []
             if source:
@@ -115,7 +122,7 @@ class HiveMapper:
                 "peer": n.peer,
                 "site_id": n.site_id,
                 "timestamp": n.timestamp,
-                "rtt_ms": n.rtt_ms,
+                "latency_ms": n.latency_ms,
             }
             for n in self.nodes.values()
         ]
@@ -164,9 +171,9 @@ class HiveMapper:
                 connector = "└── " if is_last else "├── "
                 node = self.nodes.get(peer)
                 site = f"  site={node.site_id}" if node and node.site_id else ""
-                rtt = (f"  rtt={node.rtt_ms:.0f}ms"
-                       if node and node.rtt_ms is not None else "")
-                lines.append(f"{prefix}{connector}{peer}{site}{rtt}")
+                lat = (f"  latency={node.latency_ms:.0f}ms"
+                       if node and node.latency_ms is not None else "")
+                lines.append(f"{prefix}{connector}{peer}{site}{lat}")
                 kids = display_children.get(peer, [])
                 child_prefix = prefix + ("    " if is_last else "│   ")
                 for i, kid in enumerate(kids):
@@ -196,9 +203,9 @@ class HiveMapper:
                 connector = "└── " if is_last else "├── "
                 node = self.nodes.get(peer)
                 site = f"  site={node.site_id}" if node and node.site_id else ""
-                rtt = (f"  rtt={node.rtt_ms:.0f}ms"
-                       if node and node.rtt_ms is not None else "")
-                lines.append(f"{prefix}{connector}{peer}{site}{rtt}")
+                lat = (f"  latency={node.latency_ms:.0f}ms"
+                       if node and node.latency_ms is not None else "")
+                lines.append(f"{prefix}{connector}{peer}{site}{lat}")
                 kids = children.get(peer, [])
                 child_prefix = prefix + ("    " if is_last else "│   ")
                 for i, kid in enumerate(kids):

--- a/hivemind_bus_client/message.py
+++ b/hivemind_bus_client/message.py
@@ -121,7 +121,7 @@ class HiveMessage:
 
     @property
     def route(self) -> List[str]:
-        return [r for r in self._route if r.get("targets") and r.get("source")]
+        return [r for r in self._route if isinstance(r, dict) and r.get("targets") and r.get("source")]
 
     @property
     def payload(self) -> Union['HiveMessage', Message, dict, bytes]:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -1,6 +1,7 @@
 import pybase64
-from dataclasses import dataclass
-from typing import Optional, Tuple
+import time
+from dataclasses import dataclass, field
+from typing import Optional
 
 from ovos_bus_client import Message as MycroftMessage
 from ovos_bus_client import MessageBusClient
@@ -25,7 +26,7 @@ class HiveMindSlaveInternalProtocol:
     node_id: str = ""  # this is how ovos-core bus refers to this slave's master
 
     def register_bus_handlers(self):
-        self.bus.on("hive.send.upstream", self.handle_send)
+        self.bus.on("hive.send.upstream", self.handle_send) # meant for internal usage by agent protocol plugins
         self.bus.on("message", self.handle_outgoing_mycroft)  # catch all
 
     # mycroft handlers  - from slave -> master
@@ -90,6 +91,7 @@ class HiveMindSlaveProtocol:
     shared_bus: bool = False
     binarize: bool = False
     site_id: str = "unknown"
+    _seen_flood_ids: set = field(default_factory=set)
 
     def bind(self, bus: Optional[MessageBusClient] = None):
         if self.identity is None:
@@ -241,13 +243,8 @@ class HiveMindSlaveProtocol:
             # if the message targets our site_id, send it to internal bus
             site = message.target_site_id
             if site and site == self.site_id:
+                # always trusted, comes from a master, never from other satellite
                 self.handle_bus(message.payload)
-
-        # if this device is also a hivemind server
-        # forward to HiveMindListenerInternalProtocol
-        data = message.serialize()
-        ctxt = {"source": self.node_id}
-        self.internal_protocol.bus.emit(MycroftMessage('hive.send.downstream', data, ctxt))
 
     def handle_propagate(self, message: HiveMessage):
         LOG.info(f"PROPAGATE: {message.payload}")
@@ -255,6 +252,8 @@ class HiveMindSlaveProtocol:
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             if self.handle_intercom(message):
                 return True
+        elif message.payload.msg_type == HiveMessageType.PING:
+            self._handle_ping(message)
 
         if message.payload.msg_type == HiveMessageType.BUS:
             # if the message targets our site_id, send it to internal bus
@@ -266,11 +265,46 @@ class HiveMindSlaveProtocol:
                 pass  # TODO - when to inject ? add list of trusted peers?
                 # self.handle_bus(message.payload)
 
-        # if this device is also a hivemind server
-        # forward to HiveMindListenerInternalProtocol
-        data = message.serialize()
-        ctxt = {"source": self.node_id}
-        self.internal_protocol.bus.emit(MycroftMessage('hive.send.downstream', data, ctxt))
+    def _handle_ping(self, message: HiveMessage):
+        """Handle a received PROPAGATE(PING) using flood-based discovery.
+
+        Emits ``hive.ping.received`` on the internal bus, then — if this
+        ``flood_id`` has not been seen before — builds and sends this node's
+        own responsive PING (same ``flood_id``) upstream.
+
+        Args:
+            message: The outer PROPAGATE HiveMessage whose inner payload is a PING.
+        """
+        inner = message.payload
+        ping_payload = inner.payload if isinstance(inner.payload, dict) else {}
+
+        flood_id = ping_payload.get("flood_id", "")
+
+        # Lazy init for tests that bypass bind()
+        if not hasattr(self, '_seen_flood_ids'):
+            self._seen_flood_ids = set()
+
+        # Flood-loop prevention
+        if not flood_id or flood_id in self._seen_flood_ids:
+            return
+        # Cap set size to prevent unbounded memory growth
+        if len(self._seen_flood_ids) > 1000:
+            self._seen_flood_ids.clear()
+        self._seen_flood_ids.add(flood_id)
+
+        # Build our own responsive PING with the same flood_id
+        peer = f"{self.identity.name or 'satellite'}::{self.hm.session_id}"
+        own_ping_payload = {
+            "flood_id": flood_id,
+            "peer": peer,
+            "site_id": self.site_id,
+            "timestamp": time.time(),
+        }
+        own_ping_inner = HiveMessage(HiveMessageType.PING, own_ping_payload)
+        own_ping_outer = HiveMessage(HiveMessageType.PROPAGATE, payload=own_ping_inner)
+
+        LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
+        self.hm.emit(own_ping_outer)
 
     def handle_intercom(self, message: HiveMessage):
         LOG.info(f"INTERCOM: {message.payload}")
@@ -296,7 +330,7 @@ class HiveMindSlaveProtocol:
                 decrypted = decrypt_RSA(private_key, ciphertext).decode("utf8")
 
                 message._payload = HiveMessage.deserialize(decrypted)
-            except:
+            except Exception as e:
                 if k:
                     LOG.error("failed to decrypt message!")
                 else:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -268,9 +268,8 @@ class HiveMindSlaveProtocol:
     def _handle_ping(self, message: HiveMessage):
         """Handle a received PROPAGATE(PING) using flood-based discovery.
 
-        Emits ``hive.ping.received`` on the internal bus, then — if this
-        ``flood_id`` has not been seen before — builds and sends this node's
-        own responsive PING (same ``flood_id``) upstream.
+        If this ``flood_id`` has not been seen before, builds and sends
+        this node's own responsive PING (same ``flood_id``) upstream.
 
         Args:
             message: The outer PROPAGATE HiveMessage whose inner payload is a PING.
@@ -287,9 +286,10 @@ class HiveMindSlaveProtocol:
         # Flood-loop prevention
         if not flood_id or flood_id in self._seen_flood_ids:
             return
-        # Cap set size to prevent unbounded memory growth
-        if len(self._seen_flood_ids) > 1000:
-            self._seen_flood_ids.clear()
+        # Evict oldest entries when cache is full (FIFO-ish; avoids
+        # clearing the entire set which could let duplicates through)
+        while len(self._seen_flood_ids) >= 1000:
+            self._seen_flood_ids.pop()
         self._seen_flood_ids.add(flood_id)
 
         # Build our own responsive PING with the same flood_id

--- a/hivemind_bus_client/scripts.py
+++ b/hivemind_bus_client/scripts.py
@@ -230,12 +230,12 @@ def ping(key: str, password: str, host: str, port: int, siteid: str,
     siteid = siteid or identity.site_id or "unknown"
     port = port or identity.default_port or 5678
 
-    if not host.startswith("ws://") and not host.startswith("wss://"):
-        host = "ws://" + host
-
     if not key or not password or not host:
         raise RuntimeError("NodeIdentity not set, please pass key/password/host or "
                            "call 'hivemind-client set-identity'")
+
+    if not host.startswith("ws://") and not host.startswith("wss://"):
+        host = "ws://" + host
 
     mapper = HiveMapper()
     flood_id = str(uuid.uuid4())
@@ -243,7 +243,9 @@ def ping(key: str, password: str, host: str, port: int, siteid: str,
 
     node = HiveMessageBusClient(key, host=host, port=port, password=password)
     node.connect(FakeBus(), site_id=siteid)
-    node.connected_event.wait(timeout=10)
+    if not node.connected_event.wait(timeout=10):
+        print("[ERROR] Failed to connect to HiveMind within 10 seconds")
+        return
     print(f"== connected to HiveMind, sending PING (timeout={timeout}s)")
 
     mapper.start_ping(flood_id)

--- a/hivemind_bus_client/scripts.py
+++ b/hivemind_bus_client/scripts.py
@@ -1,14 +1,16 @@
 import json
+import time
+import uuid
 
 import click
 from ovos_bus_client import Message
 from ovos_utils.log import LOG
 from ovos_utils.fakebus import FakeBus
-
+from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.identity import NodeIdentity
-LOG.set_level("DEBUG")
+LOG.set_level("ERROR")
 
 
 @click.group()
@@ -205,6 +207,91 @@ def reset_keys():
     print("PUBKEY:", identity.public_key)
     identity.save()
     print(f"identity saved: {identity.IDENTITY_FILE.path}")
+
+
+@hmclient_cmds.command(
+    help="Send a PING and display the reachable hive map.",
+    name="ping",
+)
+@click.option("--key", help="HiveMind access key (default read from identity file)", type=str, default="")
+@click.option("--password", help="HiveMind password (default read from identity file)", type=str, default="")
+@click.option("--host", help="HiveMind host (default read from identity file)", type=str, default="")
+@click.option("--port", help="HiveMind port number (default: 5678)", type=int, required=False)
+@click.option("--siteid", help="location identifier (default read from identity file)", type=str, default="")
+@click.option("--timeout", help="seconds to collect responses (default: 5.0)", type=float, default=5.0)
+@click.option("--json", "output_json", is_flag=True, default=False, help="output raw JSON topology")
+def ping(key: str, password: str, host: str, port: int, siteid: str,
+         timeout: float, output_json: bool):
+    """Send a PING flood and collect responsive PINGs to map the hive topology."""
+    identity = NodeIdentity()
+    password = password or identity.password
+    key = key or identity.access_key
+    host = host or identity.default_master
+    siteid = siteid or identity.site_id or "unknown"
+    port = port or identity.default_port or 5678
+
+    if not host.startswith("ws://") and not host.startswith("wss://"):
+        host = "ws://" + host
+
+    if not key or not password or not host:
+        raise RuntimeError("NodeIdentity not set, please pass key/password/host or "
+                           "call 'hivemind-client set-identity'")
+
+    mapper = HiveMapper()
+    flood_id = str(uuid.uuid4())
+    my_peer = f"{identity.name or 'hivemind-client'}::{flood_id[:8]}"
+
+    node = HiveMessageBusClient(key, host=host, port=port, password=password)
+    node.connect(FakeBus(), site_id=siteid)
+    node.connected_event.wait(timeout=10)
+    print(f"== connected to HiveMind, sending PING (timeout={timeout}s)")
+
+    mapper.start_ping(flood_id)
+
+    def on_ping_response(outer: HiveMessage):
+        """Handle a PROPAGATE message whose inner payload is a responsive PING."""
+        inner = outer.payload
+        if not isinstance(inner, HiveMessage):
+            return
+        if inner.msg_type != HiveMessageType.PING:
+            return
+        ping_data = inner.payload
+        if not isinstance(ping_data, dict):
+            return
+        if ping_data.get("flood_id") != flood_id:
+            return
+        # Transfer route from outer PROPAGATE to inner PING so HiveMapper can read it
+        inner.replace_route(outer.route)
+        if mapper.on_ping(inner, received_at=time.time()):
+            peer = ping_data.get("peer", "?")
+            site = ping_data.get("site_id", "")
+            site_str = f"  site={site}" if site else ""
+            print(f"  PING from {peer}{site_str}")
+
+    node.on(HiveMessageType.PROPAGATE, on_ping_response)
+
+    ping_payload = {
+        "flood_id": flood_id,
+        "timestamp": time.time(),
+        "peer": my_peer,
+        "site_id": siteid,
+    }
+    ping_inner = HiveMessage(HiveMessageType.PING, ping_payload)
+    ping_outer = HiveMessage(HiveMessageType.PROPAGATE, payload=ping_inner)
+    node.emit(ping_outer)
+
+    time.sleep(timeout)
+    node.close()
+
+    if not mapper.nodes:
+        print("[No responses received within the timeout window]")
+        return
+
+    if output_json:
+        print(mapper.to_json())
+    else:
+        print("\n== Hive Map ==")
+        print(mapper.to_ascii(root_peer=my_peer))
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_hive_map.py
+++ b/test/unittests/test_hive_map.py
@@ -1,0 +1,167 @@
+"""Tests for hivemind_bus_client.hive_map — HiveMapper and NodeInfo."""
+import json
+import pytest
+from hivemind_bus_client.hive_map import HiveMapper, NodeInfo
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+
+class TestNodeInfo:
+    def test_rtt_ms_both_timestamps(self):
+        node = NodeInfo(peer="a", timestamp=100.0, received_at=100.05)
+        assert node.rtt_ms == pytest.approx(50.0)
+
+    def test_rtt_ms_missing_timestamp(self):
+        node = NodeInfo(peer="a", received_at=100.0)
+        assert node.rtt_ms is None
+
+    def test_rtt_ms_missing_received(self):
+        node = NodeInfo(peer="a", timestamp=100.0)
+        assert node.rtt_ms is None
+
+    def test_rtt_ms_both_none(self):
+        node = NodeInfo(peer="a")
+        assert node.rtt_ms is None
+
+
+def _make_ping(flood_id: str, peer: str, site_id: str = "",
+               route: list = None, timestamp: float = None) -> HiveMessage:
+    """Helper: build a PING HiveMessage with optional route."""
+    payload = {"flood_id": flood_id, "peer": peer, "site_id": site_id}
+    if timestamp is not None:
+        payload["timestamp"] = timestamp
+    msg = HiveMessage(HiveMessageType.PING, payload, route=route or [])
+    return msg
+
+
+class TestHiveMapperOnPing:
+    def test_new_ping_returns_true(self):
+        mapper = HiveMapper()
+        mapper.start_ping("flood1")
+        msg = _make_ping("flood1", "nodeA")
+        assert mapper.on_ping(msg) is True
+        assert "nodeA" in mapper.nodes
+
+    def test_duplicate_ping_returns_false(self):
+        mapper = HiveMapper()
+        mapper.start_ping("flood1")
+        msg = _make_ping("flood1", "nodeA")
+        mapper.on_ping(msg)
+        assert mapper.on_ping(msg) is False
+
+    def test_empty_peer_ignored(self):
+        mapper = HiveMapper()
+        mapper.start_ping("flood1")
+        msg = _make_ping("flood1", "")
+        assert mapper.on_ping(msg) is False
+
+    def test_non_dict_payload_ignored(self):
+        mapper = HiveMapper()
+        # HiveMessageType.PING with a non-dict payload (raw string won't happen
+        # in practice but tests the guard)
+        msg = HiveMessage(HiveMessageType.THIRDPRTY, {"flood_id": "x", "peer": "y"})
+        # msg_type is THIRDPRTY so payload returns dict — but for PING type,
+        # payload is returned as-is (dict). Let's test with a proper PING.
+        msg2 = HiveMessage(HiveMessageType.PING, {})
+        assert mapper.on_ping(msg2) is False
+
+    def test_route_edges_extracted(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        route = [{"source": "hub", "targets": ["relay1"]},
+                 {"source": "relay1", "targets": ["nodeA"]}]
+        msg = _make_ping("f1", "nodeA", route=route)
+        mapper.on_ping(msg)
+        assert "hub" in mapper.edges
+        assert "relay1" in mapper.edges["hub"]
+        assert "relay1" in mapper.edges
+        assert "nodeA" in mapper.edges["relay1"]
+
+    def test_node_info_populated(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        msg = _make_ping("f1", "nodeA", site_id="kitchen", timestamp=1000.0)
+        mapper.on_ping(msg, received_at=1000.05)
+        node = mapper.nodes["nodeA"]
+        assert node.site_id == "kitchen"
+        assert node.rtt_ms == pytest.approx(50.0)
+
+    def test_auto_creates_seen_set_for_unknown_flood_id(self):
+        mapper = HiveMapper()
+        # Don't call start_ping — on_ping should auto-create the set
+        msg = _make_ping("unknown_flood", "nodeX")
+        assert mapper.on_ping(msg) is True
+
+    def test_multiple_floods_independent(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        mapper.start_ping("f2")
+        msg1 = _make_ping("f1", "nodeA")
+        msg2 = _make_ping("f2", "nodeA")
+        assert mapper.on_ping(msg1) is True
+        assert mapper.on_ping(msg2) is True
+        # Same peer, different flood_id — both accepted
+
+
+class TestHiveMapperToDict:
+    def test_empty_mapper(self):
+        mapper = HiveMapper()
+        d = mapper.to_dict()
+        assert d == {"nodes": [], "edges": []}
+
+    def test_nodes_and_edges(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        route = [{"source": "hub", "targets": ["nodeA"]}]
+        mapper.on_ping(_make_ping("f1", "nodeA", site_id="lr", route=route,
+                                   timestamp=10.0), received_at=10.1)
+        d = mapper.to_dict()
+        assert len(d["nodes"]) == 1
+        assert d["nodes"][0]["peer"] == "nodeA"
+        assert d["nodes"][0]["site_id"] == "lr"
+        assert len(d["edges"]) == 1
+        assert d["edges"][0] == {"source": "hub", "target": "nodeA"}
+
+
+class TestHiveMapperToJson:
+    def test_valid_json(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        mapper.on_ping(_make_ping("f1", "nodeA"))
+        result = json.loads(mapper.to_json())
+        assert "nodes" in result
+        assert "edges" in result
+
+
+class TestHiveMapperToAscii:
+    def test_empty_returns_no_nodes(self):
+        mapper = HiveMapper()
+        assert mapper.to_ascii() == "[No nodes discovered]"
+
+    def test_single_node_with_root(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        route = [{"source": "nodeA", "targets": ["root"]}]
+        mapper.on_ping(_make_ping("f1", "nodeA", site_id="lr", route=route))
+        tree = mapper.to_ascii(root_peer="root")
+        assert "[self] root" in tree
+        assert "nodeA" in tree
+
+    def test_without_root_peer(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        route = [{"source": "hub", "targets": ["nodeA"]}]
+        mapper.on_ping(_make_ping("f1", "nodeA", route=route))
+        tree = mapper.to_ascii()
+        assert "hub" in tree
+        assert "nodeA" in tree
+
+
+class TestHiveMapperClear:
+    def test_clear_resets_state(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        mapper.on_ping(_make_ping("f1", "nodeA"))
+        mapper.clear()
+        assert mapper.nodes == {}
+        assert mapper.edges == {}
+        assert mapper._seen_pings == {}

--- a/test/unittests/test_hive_map.py
+++ b/test/unittests/test_hive_map.py
@@ -6,21 +6,21 @@ from hivemind_bus_client.message import HiveMessage, HiveMessageType
 
 
 class TestNodeInfo:
-    def test_rtt_ms_both_timestamps(self):
+    def test_latency_ms_both_timestamps(self):
         node = NodeInfo(peer="a", timestamp=100.0, received_at=100.05)
-        assert node.rtt_ms == pytest.approx(50.0)
+        assert node.latency_ms == pytest.approx(50.0)
 
-    def test_rtt_ms_missing_timestamp(self):
+    def test_latency_ms_missing_timestamp(self):
         node = NodeInfo(peer="a", received_at=100.0)
-        assert node.rtt_ms is None
+        assert node.latency_ms is None
 
-    def test_rtt_ms_missing_received(self):
+    def test_latency_ms_missing_received(self):
         node = NodeInfo(peer="a", timestamp=100.0)
-        assert node.rtt_ms is None
+        assert node.latency_ms is None
 
-    def test_rtt_ms_both_none(self):
+    def test_latency_ms_both_none(self):
         node = NodeInfo(peer="a")
-        assert node.rtt_ms is None
+        assert node.latency_ms is None
 
 
 def _make_ping(flood_id: str, peer: str, site_id: str = "",
@@ -54,6 +54,19 @@ class TestHiveMapperOnPing:
         msg = _make_ping("flood1", "")
         assert mapper.on_ping(msg) is False
 
+    def test_empty_flood_id_ignored(self):
+        mapper = HiveMapper()
+        msg = _make_ping("", "nodeA")
+        assert mapper.on_ping(msg) is False
+
+    def test_malformed_route_hop_skipped(self):
+        mapper = HiveMapper()
+        mapper.start_ping("f1")
+        route = [{"source": "hub", "targets": ["nodeA"]}, "malformed"]
+        msg = _make_ping("f1", "nodeA", route=route)
+        mapper.on_ping(msg)
+        assert "hub" in mapper.edges
+
     def test_non_dict_payload_ignored(self):
         mapper = HiveMapper()
         # HiveMessageType.PING with a non-dict payload (raw string won't happen
@@ -83,7 +96,7 @@ class TestHiveMapperOnPing:
         mapper.on_ping(msg, received_at=1000.05)
         node = mapper.nodes["nodeA"]
         assert node.site_id == "kitchen"
-        assert node.rtt_ms == pytest.approx(50.0)
+        assert node.latency_ms == pytest.approx(50.0)
 
     def test_auto_creates_seen_set_for_unknown_flood_id(self):
         mapper = HiveMapper()

--- a/test/unittests/test_protocol.py
+++ b/test/unittests/test_protocol.py
@@ -56,15 +56,14 @@ class TestHandlePing:
         proto.hm.emit.assert_not_called()
 
     def test_flood_id_set_capped(self):
-        """When _seen_flood_ids exceeds 1000, it should be cleared."""
+        """When _seen_flood_ids reaches 1000, oldest entries are evicted."""
         proto = _make_protocol()
-        proto._seen_flood_ids = {str(i) for i in range(1001)}
+        proto._seen_flood_ids = {str(i) for i in range(1000)}
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "new", "peer": "other"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
         proto._handle_ping(outer)
-        # Set was cleared and "new" was added
         assert "new" in proto._seen_flood_ids
-        assert len(proto._seen_flood_ids) == 1
+        assert len(proto._seen_flood_ids) == 1000
 
     def test_different_flood_ids_both_processed(self):
         proto = _make_protocol()

--- a/test/unittests/test_protocol.py
+++ b/test/unittests/test_protocol.py
@@ -1,0 +1,86 @@
+"""Tests for hivemind_bus_client.protocol — HiveMindSlaveProtocol PING handling."""
+from unittest.mock import MagicMock, patch
+import pytest
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+from hivemind_bus_client.identity import NodeIdentity
+
+
+def _make_protocol() -> HiveMindSlaveProtocol:
+    """Create a minimal HiveMindSlaveProtocol with mocked dependencies."""
+    hm = MagicMock()
+    hm.session_id = "test-session"
+    identity = MagicMock(spec=NodeIdentity)
+    identity.name = "test-node"
+    identity.password = "test"
+    proto = HiveMindSlaveProtocol(hm=hm, identity=identity, site_id="living-room")
+    proto._seen_flood_ids = set()
+    return proto
+
+
+class TestHandlePing:
+    def test_sends_responsive_ping(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
+        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+        proto._handle_ping(outer)
+
+        proto.hm.emit.assert_called_once()
+        sent = proto.hm.emit.call_args[0][0]
+        assert sent.msg_type == HiveMessageType.PROPAGATE
+        inner_sent = sent.payload
+        assert isinstance(inner_sent, HiveMessage)
+        assert inner_sent.msg_type == HiveMessageType.PING
+        payload = inner_sent.payload
+        assert payload["flood_id"] == "abc"
+        assert payload["peer"] == "test-node::test-session"
+        assert payload["site_id"] == "living-room"
+
+    def test_duplicate_flood_id_ignored(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
+        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+        proto._handle_ping(outer)
+        proto.hm.emit.reset_mock()
+
+        # Second call with same flood_id
+        proto._handle_ping(outer)
+        proto.hm.emit.assert_not_called()
+
+    def test_empty_flood_id_ignored(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.PING, {"flood_id": "", "peer": "other"})
+        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+        proto._handle_ping(outer)
+        proto.hm.emit.assert_not_called()
+
+    def test_flood_id_set_capped(self):
+        """When _seen_flood_ids exceeds 1000, it should be cleared."""
+        proto = _make_protocol()
+        proto._seen_flood_ids = {str(i) for i in range(1001)}
+        inner = HiveMessage(HiveMessageType.PING, {"flood_id": "new", "peer": "other"})
+        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+        proto._handle_ping(outer)
+        # Set was cleared and "new" was added
+        assert "new" in proto._seen_flood_ids
+        assert len(proto._seen_flood_ids) == 1
+
+    def test_different_flood_ids_both_processed(self):
+        proto = _make_protocol()
+        for fid in ["flood1", "flood2"]:
+            inner = HiveMessage(HiveMessageType.PING, {"flood_id": fid, "peer": "other"})
+            outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+            proto._handle_ping(outer)
+        assert proto.hm.emit.call_count == 2
+
+
+class TestHandlePropagate:
+    def test_ping_dispatched(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "x"})
+        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
+
+        with patch.object(proto, '_handle_ping') as mock_ping:
+            proto.handle_propagate(outer)
+            mock_ping.assert_called_once_with(outer)


### PR DESCRIPTION
Add HiveMapper/NodeInfo (hive_map.py) to collect PING responses and render the network topology as ASCII tree or JSON. Satellites now handle PROPAGATE(PING) with flood_id deduplication and respond with their own PING upstream. New `hivemind-client ping` CLI command initiates a flood and displays the reachable hive map.

Also fixes:
- HiveMessage.__init__ now normalizes nested HiveMessage payloads
- BitStream bool() bug in serialization (was always True)
- Replace bare except with except Exception
- Remove dead downstream forwarding from handle_broadcast/handle_propagate

Includes initial docs/ structure, FAQ, and CLI reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `ping` subcommand to the CLI that discovers and displays the reachable hive network topology, including all connected nodes and their network relationships.
  * The command includes options for JSON output format and configurable timeout settings for discovery operations.

* **Tests**
  * Added comprehensive unit tests validating topology discovery functionality, PING protocol handling, and response processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->