### PR TITLE
[codex] Fix control-plane protocol handling

### DIFF
--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -222,7 +222,8 @@ class HiveMindSlaveProtocol:
         # may also send HELLO with their pubkey
         # only want this on the first connection
         LOG.info(f"HELLO: {message.payload}")
-        assert message.payload.msg_type == HiveMessageType.HELLO
+        # HELLO carries a plain dict payload, not a nested HiveMessage.
+        assert message.msg_type == HiveMessageType.HELLO
         if not self.node_id:
             self.mpubkey = message.payload.get("pubkey")
             node_id = message.payload.get("node_id", "")
@@ -272,7 +273,8 @@ class HiveMindSlaveProtocol:
 
     def handle_handshake(self, message: HiveMessage):
         LOG.info(f"HANDSHAKE: {message.payload}")
-        assert message.payload.msg_type == HiveMessageType.HANDSHAKE
+        # HANDSHAKE also carries a plain dict payload negotiated on the wire.
+        assert message.msg_type == HiveMessageType.HANDSHAKE
         # master is performing the handshake
         if "envelope" in message.payload:
             envelope = message.payload["envelope"]
@@ -285,21 +287,19 @@ class HiveMindSlaveProtocol:
 
         # master is requesting handshake start
         else:
-            # required = message.payload.get("handshake")
-            # if not required:
-            #    self.hm.handshake_event.set()  # don't wait
-            #    return
-
             encodings = message.payload.get("encodings") or [SupportedEncodings.JSON_HEX]
             ciphers = message.payload.get("ciphers") or [SupportedCiphers.AES_GCM]
             LOG.debug(f"Server supported encodings: {encodings}")
             LOG.debug(f"Server supported ciphers: {ciphers}")
-            if message.payload.get("crypto_key") and self.hm.crypto_key:
-                pass
-                # we can use the pre-shared key instead of handshake
-                # TODO - flag to give preference to pre-shared key over handshake
 
             self.binarize = message.payload.get("binarize", False)
+            required = message.payload.get("handshake", True)
+            if not required:
+                # HiveMind-core uses this to indicate the connection can proceed
+                # without a key-exchange round trip.
+                self.hm.handshake_event.set()
+                return
+
             # TODO - flag to give preference to / require password or use RSA handshake
             # currently if password is set then it is always used
             if message.payload.get("password") and self.identity.password:
@@ -337,7 +337,8 @@ class HiveMindSlaveProtocol:
     def handle_bus(self, message: HiveMessage):
         """Dispatch event to the agent protocol bus"""
         LOG.info(f"BUS: {message.payload.msg_type}")
-        assert message.payload.msg_type == HiveMessageType.BUS
+        # BUS frames carry a Mycroft Message payload.
+        assert message.msg_type == HiveMessageType.BUS
         assert isinstance(message.payload, MycroftMessage)
         # master wants to inject message into mycroft bus
         pload = message.payload

--- a/test/unittests/test_protocol_handshake.py
+++ b/test/unittests/test_protocol_handshake.py
@@ -1,0 +1,75 @@
+"""Regression tests for HELLO/HANDSHAKE payload handling."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+
+
+def _make_protocol() -> HiveMindSlaveProtocol:
+    hm = MagicMock()
+    hm.session_id = "test-session"
+    hm.handshake_event = MagicMock()
+    identity = MagicMock(spec=NodeIdentity)
+    identity.name = "test-node"
+    identity.password = "test"
+    proto = HiveMindSlaveProtocol(hm=hm, identity=identity, site_id="living-room")
+    proto.internal_protocol = MagicMock()
+    proto.internal_protocol.node_id = ""
+    proto.internal_protocol.bus = MagicMock()
+    return proto
+
+
+class TestHelloAndHandshakePayloads(unittest.TestCase):
+    def test_handle_hello_accepts_dict_payload(self):
+        proto = _make_protocol()
+        msg = HiveMessage(HiveMessageType.HELLO,
+                          {"pubkey": "master-pubkey", "node_id": "master-1"})
+
+        proto.handle_hello(msg)
+
+        self.assertEqual(proto.mpubkey, "master-pubkey")
+        self.assertEqual(proto.internal_protocol.node_id, "master-1")
+
+    def test_handle_handshake_accepts_dict_payload(self):
+        proto = _make_protocol()
+        msg = HiveMessage(HiveMessageType.HANDSHAKE,
+                          {"password": True, "binarize": True})
+
+        with patch.object(proto, "start_handshake") as mock_start:
+            proto.handle_handshake(msg)
+
+        self.assertTrue(proto.binarize)
+        mock_start.assert_called_once()
+
+    def test_handle_handshake_allows_no_key_exchange_when_core_marks_it_optional(self):
+        proto = _make_protocol()
+        proto.hm.crypto_key = "existing-session-key"
+        msg = HiveMessage(HiveMessageType.HANDSHAKE,
+                          {"handshake": False, "preshared_key": True, "binarize": True})
+
+        with patch.object(proto, "start_handshake") as mock_start:
+            proto.handle_handshake(msg)
+
+        self.assertTrue(proto.binarize)
+        proto.hm.handshake_event.set.assert_called_once_with()
+        mock_start.assert_not_called()
+
+    def test_handle_bus_accepts_outer_bus_frame(self):
+        proto = _make_protocol()
+        inner = Message("speak", {"utterance": "hello"}, {"destination": "HiveMind"})
+        msg = HiveMessage(HiveMessageType.BUS, inner)
+
+        fake_session = MagicMock()
+        fake_session.session_id = "remote-session"
+
+        with patch("hivemind_bus_client.protocol.Session.from_message", return_value=fake_session) as mock_from_message:
+            with patch("hivemind_bus_client.protocol.SessionManager.update") as mock_update:
+                proto.handle_bus(msg)
+
+        mock_from_message.assert_called_once()
+        mock_update.assert_called_once_with(fake_session)
+        proto.internal_protocol.bus.emit.assert_called_once()


### PR DESCRIPTION
## What changed
This PR fixes the client-side handling of `HELLO`, `HANDSHAKE`, and top-level `BUS` frames so the websocket client matches the wire format used by current `HiveMind-core`.

## Why
Issue #104 was caused by treating `HELLO` and `HANDSHAKE` payloads as nested `HiveMessage` objects when `HiveMind-core` sends plain dict payloads. While aligning that path, this also fixes top-level `BUS` validation and the `handshake: false` path used when no extra key exchange is required.

## Impact
Clients can complete the control-plane handshake reliably against current `HiveMind-core` and no longer raise `AttributeError: 'dict' object has no attribute 'msg_type'` during connection setup.

## Validation
- `python -m unittest test.unittests.test_protocol_handshake`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message type validation in protocol handling for HELLO, HANDSHAKE, and BUS message types.
  * Updated handshake mechanism to support conditional key-exchange sequences.

* **Tests**
  * Added comprehensive test coverage for handshake functionality and protocol message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->