### PR TITLE
[codex] Align INTERCOM with HiveMind-core

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -19,8 +19,8 @@ from hivemind_bus_client.serialization import HiveMindBinaryPayloadType
 from hivemind_bus_client.serialization import get_bitstring, decode_bitstring
 from hivemind_bus_client.util import serialize_message
 from hivemind_bus_client.encryption import (encrypt_as_json, decrypt_from_json, encrypt_bin, decrypt_bin,
-                                            SupportedEncodings, SupportedCiphers, hybrid_encrypt)
-from poorman_handshake.asymmetric.utils import load_RSA_key, sign_RSA
+                                            SupportedEncodings, SupportedCiphers)
+from poorman_handshake.asymmetric.utils import load_RSA_key, sign_RSA, encrypt_RSA
 
 
 class BinaryDataCallbacks:
@@ -537,16 +537,19 @@ class HiveMessageBusClient(OVOSBusClient):
     # targeted messages for nodes, asymmetric encryption
     def emit_intercom(self, message: Union[MycroftMessage, HiveMessage],
                       pubkey: Union[str, bytes, 'RSA.RsaKey']):
-        """Send an INTERCOM message using hybrid encryption.
+        """Send an INTERCOM message using the core-compatible RSA envelope.
 
-        Generates a random AES-256 key, encrypts the payload with AES-GCM,
-        then RSA-encrypts only the AES key with the target's public key.
-        The ciphertext is signed with this node's private key.
+        The serialized payload is RSA-encrypted for the target peer and the
+        ciphertext is signed with this node's private key. This matches the
+        envelope format currently handled by HiveMind-core.
 
         Args:
             message: The message to send.
             pubkey: RSA public key of the target peer.
         """
+        encrypted_message = encrypt_RSA(pubkey, message.serialize())
         private_key = load_RSA_key(self.identity.private_key)
-        envelope = hybrid_encrypt(pubkey, message.serialize(), sign_key=private_key)
-        self.emit(HiveMessage(HiveMessageType.INTERCOM, payload=envelope))
+        signature = sign_RSA(private_key, encrypted_message)
+        self.emit(HiveMessage(HiveMessageType.INTERCOM,
+                              payload={"ciphertext": pybase64.b64encode(encrypted_message).decode("ascii"),
+                                       "signature": pybase64.b64encode(signature).decode("ascii")}))

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -1,4 +1,5 @@
 import random
+import pybase64
 
 import threading
 import time
@@ -17,7 +18,7 @@ from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from poorman_handshake import HandShake, PasswordHandShake
-from poorman_handshake.asymmetric.utils import load_RSA_key
+from poorman_handshake.asymmetric.utils import load_RSA_key, decrypt_RSA
 
 
 class CascadeAggregator:
@@ -365,7 +366,7 @@ class HiveMindSlaveProtocol:
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
 
         if message.payload.msg_type == HiveMessageType.INTERCOM:
-            self.handle_intercom(message)
+            self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.BUS:
             # if the message targets our site_id, send it to internal bus
             site = message.target_site_id
@@ -386,7 +387,7 @@ class HiveMindSlaveProtocol:
         LOG.info(f"PROPAGATE: {message.payload}")
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM, HiveMessageType.PING]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
-            self.handle_intercom(message)
+            self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.PING:
             self._handle_ping(message)
         elif message.payload.msg_type == HiveMessageType.BUS:
@@ -451,7 +452,7 @@ class HiveMindSlaveProtocol:
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             # using INTERCOM allows end2end privacy, nodes along the chain can't read responses
-            self.handle_intercom(message)
+            self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.BUS:
             self.handle_bus(message)
 
@@ -496,7 +497,7 @@ class HiveMindSlaveProtocol:
             message: The INTERCOM HiveMessage.
         """
         LOG.info(f"INTERCOM: {message.payload}")
-        assert message.payload.msg_type == HiveMessageType.BUS
+        assert message.msg_type == HiveMessageType.INTERCOM
 
         k = message.target_public_key
         if k and k != self.identity.public_key:
@@ -504,28 +505,62 @@ class HiveMindSlaveProtocol:
             return False
 
         pload = message.payload
-        if isinstance(pload, dict) and "encrypted_key" in pload:
-            # hybrid encryption envelope (AES key RSA-encrypted)
+        if isinstance(pload, dict) and "ciphertext" in pload:
             try:
                 private_key = load_RSA_key(self.identity.private_key)
-                decrypted = hybrid_decrypt(private_key, pload).decode("utf-8")
+                if "encrypted_key" in pload:
+                    # Backward-compatible with older hybrid AES+RSA envelopes.
+                    decrypted = hybrid_decrypt(private_key, pload).decode("utf-8")
+                else:
+                    ciphertext = pybase64.b64decode(pload["ciphertext"])
+                    decrypted = decrypt_RSA(private_key, ciphertext).decode("utf-8")
                 message._payload = HiveMessage.deserialize(decrypted)
-            except Exception as e:
+            except Exception:
                 if k:
                     LOG.error("failed to decrypt INTERCOM message!")
                 else:
                     LOG.debug("failed to decrypt INTERCOM, not for us")
                 return False
+        elif isinstance(pload, dict) and "msg_type" in pload:
+            message._payload = HiveMessage.deserialize(pload)
+
+        inner = message.payload
+        if not isinstance(inner, HiveMessage):
+            LOG.warning("Dropping INTERCOM without an embedded HiveMessage payload")
+            return False
 
         # explicitly targeted at us → always trust
         if k and k == self.identity.public_key:
-            self.handle_bus(message)
-            return True
+            return self._dispatch_intercom_payload(inner)
 
         # not targeted — only inject if source is trusted
         if self._is_source_trusted(message):
-            self.handle_bus(message)
-            return True
+            return self._dispatch_intercom_payload(inner)
 
         LOG.warning(f"Dropping untrusted INTERCOM from {message.source_peer}")
+        return False
+
+    def _dispatch_intercom_payload(self, message: HiveMessage) -> bool:
+        if message.msg_type == HiveMessageType.BUS:
+            self.handle_bus(message)
+            return True
+        if message.msg_type == HiveMessageType.BROADCAST:
+            self.handle_broadcast(message)
+            return True
+        if message.msg_type == HiveMessageType.PROPAGATE:
+            self.handle_propagate(message)
+            return True
+        if message.msg_type == HiveMessageType.QUERY:
+            self.handle_query(message)
+            return True
+        if message.msg_type == HiveMessageType.CASCADE:
+            self.handle_cascade(message)
+            return True
+        if message.msg_type == HiveMessageType.BINARY:
+            self.hm._handle_binary(message)
+            return True
+        if message.msg_type in [HiveMessageType.ESCALATE, HiveMessageType.SHARED_BUS]:
+            self.handle_illegal_msg(message)
+            return True
+        LOG.warning(f"Unsupported INTERCOM payload type: {message.msg_type}")
         return False

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -256,5 +256,25 @@ class TestBuildUrl(unittest.TestCase):
         self.assertTrue(url.startswith("ws://"))
 
 
+class TestEmitIntercom(unittest.TestCase):
+    @patch("hivemind_bus_client.client.sign_RSA", return_value=b"signature")
+    @patch("hivemind_bus_client.client.load_RSA_key", return_value=object())
+    @patch("hivemind_bus_client.client.encrypt_RSA", return_value=b"ciphertext")
+    def test_emit_intercom_uses_core_compatible_envelope(self, mock_encrypt, mock_load_key, mock_sign):
+        client = _make_client()
+        client.emit = MagicMock()
+        msg = Message("speak", {"utterance": "hello"})
+
+        client.emit_intercom(msg, pubkey="target-pubkey")
+
+        mock_encrypt.assert_called_once()
+        mock_sign.assert_called_once()
+        emitted = client.emit.call_args[0][0]
+        self.assertEqual(emitted.msg_type, HiveMessageType.INTERCOM)
+        self.assertIn("ciphertext", emitted.payload)
+        self.assertIn("signature", emitted.payload)
+        self.assertNotIn("encrypted_key", emitted.payload)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_protocol_intercom.py
+++ b/test/unittests/test_protocol_intercom.py
@@ -1,0 +1,89 @@
+"""Regression tests for INTERCOM compatibility with HiveMind-core."""
+import unittest
+import pybase64
+from unittest.mock import MagicMock, patch
+
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+from ovos_bus_client.message import Message
+
+
+def _make_protocol() -> HiveMindSlaveProtocol:
+    hm = MagicMock()
+    hm.session_id = "test-session"
+    hm.handshake_event = MagicMock()
+    hm._handle_binary = MagicMock()
+    identity = MagicMock(spec=NodeIdentity)
+    identity.name = "test-node"
+    identity.password = "test"
+    proto = HiveMindSlaveProtocol(hm=hm, identity=identity, site_id="living-room")
+    proto.internal_protocol = MagicMock()
+    proto.internal_protocol.node_id = ""
+    proto.internal_protocol.bus = MagicMock()
+    return proto
+
+
+class TestIntercomCompatibility(unittest.TestCase):
+    def test_handle_intercom_accepts_core_rsa_envelope(self):
+        proto = _make_protocol()
+        proto.identity.public_key = "client-pubkey"
+        inner = HiveMessage(HiveMessageType.BUS,
+                            Message("speak", {"utterance": "hello"}, {}))
+        msg = HiveMessage(HiveMessageType.INTERCOM,
+                          {"ciphertext": pybase64.b64encode(b"ciphertext").decode("ascii"),
+                           "signature": pybase64.b64encode(b"signature").decode("ascii")},
+                          target_pubkey="client-pubkey")
+
+        with patch("hivemind_bus_client.protocol.load_RSA_key", return_value=object()):
+            with patch("hivemind_bus_client.protocol.decrypt_RSA", return_value=inner.serialize().encode("utf-8")):
+                with patch.object(proto, "handle_bus") as mock_handle_bus:
+                    self.assertTrue(proto.handle_intercom(msg))
+
+        mock_handle_bus.assert_called_once()
+        self.assertEqual(mock_handle_bus.call_args[0][0].msg_type, HiveMessageType.BUS)
+
+    def test_handle_broadcast_passes_inner_intercom(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.INTERCOM,
+                            {"ciphertext": pybase64.b64encode(b"x").decode("ascii"),
+                             "signature": pybase64.b64encode(b"y").decode("ascii")})
+        msg = HiveMessage(HiveMessageType.BROADCAST, inner)
+
+        with patch.object(proto, "handle_intercom") as mock_handle_intercom:
+            proto.handle_broadcast(msg)
+
+        mock_handle_intercom.assert_called_once()
+        dispatched = mock_handle_intercom.call_args[0][0]
+        self.assertEqual(dispatched.msg_type, HiveMessageType.INTERCOM)
+        self.assertEqual(dispatched.payload["ciphertext"], inner.payload["ciphertext"])
+
+    def test_handle_propagate_passes_inner_intercom(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.INTERCOM,
+                            {"ciphertext": pybase64.b64encode(b"x").decode("ascii"),
+                             "signature": pybase64.b64encode(b"y").decode("ascii")})
+        msg = HiveMessage(HiveMessageType.PROPAGATE, inner)
+
+        with patch.object(proto, "handle_intercom") as mock_handle_intercom:
+            proto.handle_propagate(msg)
+
+        mock_handle_intercom.assert_called_once()
+        dispatched = mock_handle_intercom.call_args[0][0]
+        self.assertEqual(dispatched.msg_type, HiveMessageType.INTERCOM)
+        self.assertEqual(dispatched.payload["ciphertext"], inner.payload["ciphertext"])
+
+    def test_handle_query_passes_inner_intercom(self):
+        proto = _make_protocol()
+        inner = HiveMessage(HiveMessageType.INTERCOM,
+                            {"ciphertext": pybase64.b64encode(b"x").decode("ascii"),
+                             "signature": pybase64.b64encode(b"y").decode("ascii")})
+        msg = HiveMessage(HiveMessageType.QUERY, inner)
+
+        with patch.object(proto, "handle_intercom") as mock_handle_intercom:
+            proto.handle_query(msg)
+
+        mock_handle_intercom.assert_called_once()
+        dispatched = mock_handle_intercom.call_args[0][0]
+        self.assertEqual(dispatched.msg_type, HiveMessageType.INTERCOM)
+        self.assertEqual(dispatched.payload["ciphertext"], inner.payload["ciphertext"])


### PR DESCRIPTION
## What changed
This PR aligns websocket `INTERCOM` send and receive behavior with current `HiveMind-core`.

## Why
`HiveMind-core` currently expects an RSA `ciphertext`/`signature` envelope for `INTERCOM`, while the websocket client had drifted to a different envelope shape and also routed wrapped `INTERCOM` frames incorrectly in `BROADCAST`, `PROPAGATE`, and `QUERY` handlers.

## Impact
Direct encrypted messages use the same envelope shape as `HiveMind-core` and the client now dispatches decrypted inner hive messages consistently. The receive path remains backward-compatible with the older hybrid envelope format.

## Validation
- `python -m unittest test.unittests.test_protocol_intercom`
- `python -m unittest test.unittests.test_client`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated INTERCOM message encryption to use RSA-based envelope format with improved compatibility.
  * Added support for both legacy and new encryption formats to ensure backward compatibility.

* **Tests**
  * Added comprehensive test coverage for INTERCOM message encryption and decryption workflows.
  * Added regression tests for message routing through broadcast, propagate, and query handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->