### PR TITLE
fix: message typing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -138,8 +138,6 @@ Protocol handler used by `HiveMessageBusClient` to dispatch incoming `HiveMessag
 | `handle_cascade(message)` | `CASCADE` | Buffers responses in `CascadeAggregator`; resolves after timeout or when all known nodes have responded | `protocol.py:463` |
 | `handle_intercom(message)` | `INTERCOM` | Decrypts hybrid-encrypted payload and injects into internal bus | `protocol.py:491` |
 
-> **Note:** `handle_ping` was previously private (`_handle_ping`) and received the outer PROPAGATE wrapper. It is now public and receives the inner PING `HiveMessage` directly — `handle_propagate` calls `self.handle_ping(message.payload)`.
-
 ---
 
 ## `HiveMapper` (`hivemind_bus_client/hive_map.py:38`)

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,6 +120,28 @@ Trusted keys are stored as an alias → public key mapping in the identity file.
 
 ---
 
+## `HiveMindSlaveProtocol` (`hivemind_bus_client/protocol.py:164`)
+
+Protocol handler used by `HiveMessageBusClient` to dispatch incoming `HiveMessage` objects to the appropriate handler based on `msg_type`. Every handler asserts the message type at entry and fails loudly on misrouted messages.
+
+### Public Handler Methods
+
+| Method | Asserted `msg_type` | Notes | Source |
+|--------|---------------------|-------|--------|
+| `handle_hello(message)` | `HELLO` | Session sync at connect time | `protocol.py:220` |
+| `handle_handshake(message)` | `HANDSHAKE` | Key exchange at connect time | `protocol.py:273` |
+| `handle_bus(message)` | `BUS` | Dispatches inner `MycroftMessage` to the internal bus | `protocol.py:337` |
+| `handle_broadcast(message)` | `BROADCAST` | Inner payload must be `BUS` or `INTERCOM`; passes `message.payload` to `handle_bus` or `handle_intercom` | `protocol.py:356` |
+| `handle_propagate(message)` | `PROPAGATE` | Inner payload must be `BUS`, `INTERCOM`, or `PING`; passes `message.payload` to the appropriate handler | `protocol.py:377` |
+| `handle_ping(message)` | `PING` | Receives the **inner PING directly** (not the outer PROPAGATE wrapper); flood-loop prevention via `HiveMapper.check_flood_id` | `protocol.py:404` |
+| `handle_query(message)` | `QUERY` | Inner payload must be `BUS` or `INTERCOM` | `protocol.py:446` |
+| `handle_cascade(message)` | `CASCADE` | Buffers responses in `CascadeAggregator`; resolves after timeout or when all known nodes have responded | `protocol.py:463` |
+| `handle_intercom(message)` | `INTERCOM` | Decrypts hybrid-encrypted payload and injects into internal bus | `protocol.py:491` |
+
+> **Note:** `handle_ping` was previously private (`_handle_ping`) and received the outer PROPAGATE wrapper. It is now public and receives the inner PING `HiveMessage` directly — `handle_propagate` calls `self.handle_ping(message.payload)`.
+
+---
+
 ## `HiveMapper` (`hivemind_bus_client/hive_map.py:38`)
 
 Collects responsive PINGs from a flood and builds a directed hive topology graph.

--- a/docs/message_types.md
+++ b/docs/message_types.md
@@ -30,7 +30,7 @@ The `msg_type` (defined in `hivemind_bus_client.message.HiveMessageType`) dictat
 
 QUERY propagates upstream like ESCALATE, but stops as soon as one node can respond.
 
-**Satellite behaviour** (`HiveMindSlaveProtocol.handle_query` — `protocol.py:311`):
+**Satellite behaviour** (`HiveMindSlaveProtocol.handle_query` — `protocol.py:446`):
 - Inner payload must be `BUS` or `INTERCOM`.
 - `BUS` payloads are dispatched to `handle_bus`.
 - `INTERCOM` payloads are dispatched to `handle_intercom`.
@@ -61,7 +61,7 @@ def on_speak(msg):
 
 CASCADE propagates like PROPAGATE (bidirectional flood) but expects responses from all reachable nodes. Responses are optional — nodes that cannot answer simply stay silent.
 
-**Satellite behaviour** (`HiveMindSlaveProtocol.handle_cascade` — `protocol.py:436`):
+**Satellite behaviour** (`HiveMindSlaveProtocol.handle_cascade` — `protocol.py:463`):
 
 Responses are buffered in a `CascadeAggregator` (`protocol.py:21`). After `cascade_timeout` seconds (default 5.0) **or** when the number of responses reaches the known node count from `hive_mapper`, the `cascade_select_callback` picks the best response and emits it on the internal bus.
 
@@ -102,6 +102,10 @@ from hivemind_bus_client.decorators import on_cascade
 def on_skills(msg):
     print(msg.data["skills"])
 ```
+
+**Satellite behaviour** (`HiveMindSlaveProtocol.handle_ping` — `protocol.py:404`):
+
+`handle_propagate` extracts the inner PING `HiveMessage` from the PROPAGATE wrapper and calls `handle_ping(message.payload)` (`protocol.py:395`). `handle_ping` receives the inner PING directly — its `msg_type` is asserted to be `HiveMessageType.PING`. If the `flood_id` has not been seen before, the node builds and emits its own responsive PING (same `flood_id`) wrapped in a new PROPAGATE.
 
 ## PING Flood — Network Discovery
 

--- a/docs/message_types.md
+++ b/docs/message_types.md
@@ -105,7 +105,7 @@ def on_skills(msg):
 
 **Satellite behaviour** (`HiveMindSlaveProtocol.handle_ping` — `protocol.py:404`):
 
-`handle_propagate` extracts the inner PING `HiveMessage` from the PROPAGATE wrapper and calls `handle_ping(message.payload)` (`protocol.py:395`). `handle_ping` receives the inner PING directly — its `msg_type` is asserted to be `HiveMessageType.PING`. If the `flood_id` has not been seen before, the node builds and emits its own responsive PING (same `flood_id`) wrapped in a new PROPAGATE.
+`handle_propagate` passes the inner PING `HiveMessage` (`message.payload`) to `handle_ping` (`protocol.py:395`). `handle_ping` expects `msg_type == PING` and reads `message.payload` directly as the ping dict. If the `flood_id` has not been seen before, the node builds and emits its own responsive PING (same `flood_id`) wrapped in a new PROPAGATE.
 
 ## PING Flood — Network Discovery
 

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -386,11 +386,13 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"PROPAGATE: {message.payload}")
         assert message.msg_type == HiveMessageType.PROPAGATE
-        assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM, HiveMessageType.PING]
+        assert message.payload.msg_type in [HiveMessageType.BUS,
+                                            HiveMessageType.INTERCOM,
+                                            HiveMessageType.PING]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.PING:
-            self._handle_ping(message)
+            self.handle_ping(message.payload)
         elif message.payload.msg_type == HiveMessageType.BUS:
             site = message.target_site_id
             if site and site == self.site_id:
@@ -399,7 +401,7 @@ class HiveMindSlaveProtocol:
                 else:
                     LOG.warning(f"Dropping untrusted PROPAGATE(BUS) from {message.source_peer}")
 
-    def _handle_ping(self, message: HiveMessage):
+    def handle_ping(self, message: HiveMessage):
         """Handle a received PROPAGATE(PING) using flood-based discovery.
 
         If this ``flood_id`` has not been seen before, builds and sends

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -411,8 +411,7 @@ class HiveMindSlaveProtocol:
             message: The outer PROPAGATE HiveMessage whose inner payload is a PING.
         """
         assert message.msg_type == HiveMessageType.PING
-        inner = message.payload
-        ping_payload = inner.payload if isinstance(inner.payload, dict) else {}
+        ping_payload = message.payload if isinstance(message.payload, dict) else {}
 
         flood_id = ping_payload.get("flood_id", "")
 

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -222,7 +222,7 @@ class HiveMindSlaveProtocol:
         # may also send HELLO with their pubkey
         # only want this on the first connection
         LOG.info(f"HELLO: {message.payload}")
-        assert message.payload.msg_type == HiveMessageType.HELLO
+        assert message.msg_type == HiveMessageType.HELLO
         if not self.node_id:
             self.mpubkey = message.payload.get("pubkey")
             node_id = message.payload.get("node_id", "")
@@ -272,7 +272,7 @@ class HiveMindSlaveProtocol:
 
     def handle_handshake(self, message: HiveMessage):
         LOG.info(f"HANDSHAKE: {message.payload}")
-        assert message.payload.msg_type == HiveMessageType.HANDSHAKE
+        assert message.msg_type == HiveMessageType.HANDSHAKE
         # master is performing the handshake
         if "envelope" in message.payload:
             envelope = message.payload["envelope"]
@@ -336,9 +336,9 @@ class HiveMindSlaveProtocol:
 
     def handle_bus(self, message: HiveMessage):
         """Dispatch event to the agent protocol bus"""
-        LOG.info(f"BUS: {message.payload.msg_type}")
-        assert message.payload.msg_type == HiveMessageType.BUS
+        assert message.msg_type == HiveMessageType.BUS
         assert isinstance(message.payload, MycroftMessage)
+        LOG.info(f"BUS: {message.payload.msg_type}")
         # master wants to inject message into mycroft bus
         pload = message.payload
 
@@ -362,10 +362,11 @@ class HiveMindSlaveProtocol:
             message: The BROADCAST HiveMessage.
         """
         LOG.info(f"BROADCAST: {message.payload}")
+        assert message.msg_type == HiveMessageType.BROADCAST
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
 
         if message.payload.msg_type == HiveMessageType.INTERCOM:
-            self.handle_intercom(message)
+            self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.BUS:
             # if the message targets our site_id, send it to internal bus
             site = message.target_site_id
@@ -384,9 +385,10 @@ class HiveMindSlaveProtocol:
             message: The PROPAGATE HiveMessage.
         """
         LOG.info(f"PROPAGATE: {message.payload}")
+        assert message.msg_type == HiveMessageType.PROPAGATE
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM, HiveMessageType.PING]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
-            self.handle_intercom(message)
+            self.handle_intercom(message.payload)
         elif message.payload.msg_type == HiveMessageType.PING:
             self._handle_ping(message)
         elif message.payload.msg_type == HiveMessageType.BUS:
@@ -406,6 +408,7 @@ class HiveMindSlaveProtocol:
         Args:
             message: The outer PROPAGATE HiveMessage whose inner payload is a PING.
         """
+        assert message.msg_type == HiveMessageType.PING
         inner = message.payload
         ping_payload = inner.payload if isinstance(inner.payload, dict) else {}
 
@@ -448,6 +451,7 @@ class HiveMindSlaveProtocol:
             message: The QUERY HiveMessage.
         """
         LOG.info(f"QUERY: {message.payload}")
+        assert message.msg_type == HiveMessageType.QUERY
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             # using INTERCOM allows end2end privacy, nodes along the chain can't read responses
@@ -468,6 +472,7 @@ class HiveMindSlaveProtocol:
             message: The CASCADE HiveMessage.
         """
         LOG.info(f"CASCADE: {message.payload}")
+        assert message.msg_type == HiveMessageType.CASCADE
         assert message.payload.msg_type == HiveMessageType.BUS
 
         # using INTERCOM allows end2end privacy, nodes along the chain can't read responses
@@ -496,6 +501,7 @@ class HiveMindSlaveProtocol:
             message: The INTERCOM HiveMessage.
         """
         LOG.info(f"INTERCOM: {message.payload}")
+        assert message.msg_type == HiveMessageType.INTERCOM
         assert message.payload.msg_type == HiveMessageType.BUS
 
         k = message.target_public_key

--- a/test/unittests/test_protocol.py
+++ b/test/unittests/test_protocol.py
@@ -24,8 +24,7 @@ class TestHandlePing:
     def test_sends_responsive_ping(self):
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
-        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto.handle_ping(outer)
+        proto.handle_ping(inner)
 
         proto.hm.emit.assert_called_once()
         sent = proto.hm.emit.call_args[0][0]
@@ -41,19 +40,17 @@ class TestHandlePing:
     def test_duplicate_flood_id_ignored(self):
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
-        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto.handle_ping(outer)
+        proto.handle_ping(inner)
         proto.hm.emit.reset_mock()
 
         # Second call with same flood_id
-        proto.handle_ping(outer)
+        proto.handle_ping(inner)
         proto.hm.emit.assert_not_called()
 
     def test_empty_flood_id_ignored(self):
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "", "peer": "other"})
-        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto.handle_ping(outer)
+        proto.handle_ping(inner)
         proto.hm.emit.assert_not_called()
 
     def test_flood_id_set_capped(self):
@@ -65,16 +62,14 @@ class TestHandlePing:
         for i in range(1000):
             mapper.check_flood_id(str(i))
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "new", "peer": "other"})
-        outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto.handle_ping(outer)
+        proto.handle_ping(inner)
         proto.hm.emit.assert_called_once()  # "new" was not seen, so ping sent
 
     def test_different_flood_ids_both_processed(self):
         proto = _make_protocol()
         for fid in ["flood1", "flood2"]:
             inner = HiveMessage(HiveMessageType.PING, {"flood_id": fid, "peer": "other"})
-            outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-            proto.handle_ping(outer)
+            proto.handle_ping(inner)
         assert proto.hm.emit.call_count == 2
 
 
@@ -285,6 +280,9 @@ class TestHandlePropagate:
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "x"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
 
-        with patch.object(proto, '_handle_ping') as mock_ping:
+        with patch.object(proto, 'handle_ping') as mock_ping:
             proto.handle_propagate(outer)
-            mock_ping.assert_called_once_with(outer)
+            mock_ping.assert_called_once()
+            called_with = mock_ping.call_args[0][0]
+            assert called_with.msg_type == HiveMessageType.PING
+            assert called_with.payload == {"flood_id": "abc", "peer": "x"}

--- a/test/unittests/test_protocol.py
+++ b/test/unittests/test_protocol.py
@@ -25,7 +25,7 @@ class TestHandlePing:
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto._handle_ping(outer)
+        proto.handle_ping(outer)
 
         proto.hm.emit.assert_called_once()
         sent = proto.hm.emit.call_args[0][0]
@@ -42,18 +42,18 @@ class TestHandlePing:
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "abc", "peer": "other"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto._handle_ping(outer)
+        proto.handle_ping(outer)
         proto.hm.emit.reset_mock()
 
         # Second call with same flood_id
-        proto._handle_ping(outer)
+        proto.handle_ping(outer)
         proto.hm.emit.assert_not_called()
 
     def test_empty_flood_id_ignored(self):
         proto = _make_protocol()
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "", "peer": "other"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto._handle_ping(outer)
+        proto.handle_ping(outer)
         proto.hm.emit.assert_not_called()
 
     def test_flood_id_set_capped(self):
@@ -66,7 +66,7 @@ class TestHandlePing:
             mapper.check_flood_id(str(i))
         inner = HiveMessage(HiveMessageType.PING, {"flood_id": "new", "peer": "other"})
         outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-        proto._handle_ping(outer)
+        proto.handle_ping(outer)
         proto.hm.emit.assert_called_once()  # "new" was not seen, so ping sent
 
     def test_different_flood_ids_both_processed(self):
@@ -74,7 +74,7 @@ class TestHandlePing:
         for fid in ["flood1", "flood2"]:
             inner = HiveMessage(HiveMessageType.PING, {"flood_id": fid, "peer": "other"})
             outer = HiveMessage(HiveMessageType.PROPAGATE, inner)
-            proto._handle_ping(outer)
+            proto.handle_ping(outer)
         assert proto.hm.emit.call_count == 2
 
 


### PR DESCRIPTION
## Summary

- **Fix assertion style across all handlers**: replace `message.payload.msg_type == X` with `message.msg_type == X` — handlers receive the already-typed `HiveMessage`, so checking the wrapper's own type is correct and avoids unnecessary payload deserialization
- **Promote `_handle_ping` → `handle_ping`**: made public and updated call site in `handle_propagate` to pass `message.payload` (the inner PING) directly, consistent with how other handlers receive their message
- **Add outer-type guard assertions** to `handle_broadcast`, `handle_propagate`, `handle_query`, `handle_cascade`, and `handle_intercom` so misrouted messages fail loudly at the entry point
- **Fix `handle_broadcast` and `handle_propagate`** to pass `message.payload` (inner message) to `handle_intercom` and `handle_ping` rather than the outer wrapper
- **Fix `handle_ping` body**: removed leftover `inner = message.payload` indirection — since the method now receives the PING directly, `ping_payload` is `message.payload`
- **Update tests**: `TestHandlePing` now calls `handle_ping(inner)` with the PING message; `TestHandlePropagate` patches `handle_ping` and verifies the call by content (object identity is unreliable since `HiveMessage.payload` deserializes on each access)

## Test plan
- [ ] `python -m pytest test/unittests/test_protocol.py` — all 19 tests pass across Python 3.10–3.14