### PR TITLE
Fix propagate ping assertion

### DIFF
--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -406,6 +406,7 @@ class HiveMindSlaveProtocol:
         Args:
             message: The outer PROPAGATE HiveMessage whose inner payload is a PING.
         """
+        assert message.msg_type == HiveMessageType.PROPAGATE
         inner = message.payload
         ping_payload = inner.payload if isinstance(inner.payload, dict) else {}
 


### PR DESCRIPTION
Fixes #108

`_handle_ping` gets the outer `PROPAGATE` message, so this checks that instead of treating it like the inner ping.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of PING message processing in the protocol handler through improved validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->