### PR TITLE
fix: send full bus session

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -384,10 +384,15 @@ class HiveMessageBusClient(OVOSBusClient):
                     updated_payload.context["platform"] = self.useragent
                 if "destination" not in updated_payload.context:
                     updated_payload.context["destination"] = "HiveMind"
-                if "session" not in updated_payload.context:
-                    updated_payload.context["session"] = {}
-                updated_payload.context["session"]["session_id"] = self.session_id
-                updated_payload.context["session"]["site_id"] = self.site_id
+                raw_session = updated_payload.context.get("session") or {}
+                if isinstance(raw_session, dict):
+                    session = Session.deserialize(raw_session).serialize()
+                    session.update(raw_session)
+                else:
+                    session = Session(self.session_id).serialize()
+                session["session_id"] = self.session_id
+                session["site_id"] = self.site_id
+                updated_payload.context["session"] = session
                 message.payload = updated_payload
 
                 # also send event to client registered handlers

--- a/test/unittests/test_client.py
+++ b/test/unittests/test_client.py
@@ -215,6 +215,24 @@ class TestHandleHiveProtocol(unittest.TestCase):
         client.emitter.emit.assert_called()
 
 
+class TestHiveMessageBusClientEmit(unittest.TestCase):
+    def test_bus_message_gets_full_session_context(self):
+        client = _make_client()
+        client.connected_event.set()
+        client.internal_bus = MagicMock()
+        client.protocol = MagicMock()
+        client.protocol.binarize = False
+
+        client.emit(Message("recognizer_loop:utterance", {"utterances": ["hello"]}))
+
+        emitted = client.internal_bus.emit.call_args[0][0]
+        session = emitted.context["session"]
+        self.assertEqual(session["session_id"], "test-session-id")
+        self.assertEqual(session["site_id"], client.site_id)
+        self.assertIn("pipeline", session)
+        self.assertIn("context", session)
+
+
 class TestHandleBinary(unittest.TestCase):
     def test_tts_audio_callback(self):
         cb = MagicMock()


### PR DESCRIPTION
Follow-up to JarbasHiveMind/HiveMind-core#79 and #104.

BUS messages now send a serialized session instead of only `session_id` and `site_id`.

Tests: `pytest`