### PR TITLE
feat: AsyncFakeHiveMessageBus alongside the async client

### DIFF
--- a/docs/fakebus.md
+++ b/docs/fakebus.md
@@ -1,0 +1,117 @@
+# Fakes
+
+`hivemind_bus_client.fakebus.AsyncFakeHiveMessageBus` is an in-process
+stand-in for [`AsyncHiveMessageBusClient`](async_client.md). It mirrors
+the real client's surface but does no WebSocket I/O and skips the
+HiveMind handshake.
+
+## When to use it
+
+- **Unit tests** for code that talks to the HiveMind bus via the async
+  client. No need to stand up `HiveMind-core` or stub the handshake by
+  hand.
+- **Embedded / runtime fallback** wherever a HiveMind client is
+  expected but no server is configured. Mirrors how
+  `ovos_utils.fakebus.FakeBus` is sometimes used as a default-bus
+  today.
+
+For **protocol-level end-to-end testing** (full master + satellite
+topology, real handshake, real serialization), use
+[hivescope](https://github.com/JarbasHiveMind/hivescope) instead.
+`AsyncFakeHiveMessageBus` is the low-level primitive; hivescope is the
+heavier harness built on top.
+
+## Quick start
+
+```python
+import asyncio
+from ovos_bus_client.message import Message as MycroftMessage
+
+from hivemind_bus_client.fakebus import AsyncFakeHiveMessageBus
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+
+async def main():
+    bus = AsyncFakeHiveMessageBus(
+        session_id="kitchen",
+        site_id="kitchen",
+        useragent="test-bridge",
+    )
+    await bus.connect()  # no-op handshake; flips connected_event + handshake_event
+
+    captured = []
+    bus.on("speak", captured.append)            # mycroft event -> internal bus
+    bus.on(HiveMessageType.BUS, lambda m: ...)  # hive event   -> emitter
+
+    await bus.emit(MycroftMessage("speak", {"utterance": "hi"}))
+
+    # request/reply
+    reply = await bus.wait_for_response(
+        HiveMessage(HiveMessageType.PING, {"flood_id": "q"}),
+        timeout=1.0,
+    )
+
+    await bus.close()
+
+
+asyncio.run(main())
+```
+
+## What's faked vs. what's real
+
+| Concern | Behaviour |
+|---|---|
+| WebSocket | None. `connect()` is a no-op that flips `connected_event` and `handshake_event`. |
+| Handshake | Skipped. `handshake_event` is set during `connect()`. |
+| Encryption / binary framing | Not exercised. `emit()` dispatches the message object directly through `pyee` rather than serializing it onto a wire. |
+| `HiveMessageType.BUS` routing-context injection | **Real** — `source`, `platform`, `destination`, and `session` are injected exactly as the real client does (`fakebus.py:175`), so session-aware downstream tests behave identically. |
+| Internal-bus dispatch (`on("speak", ...)`) | **Real** — attaches to a real `ovos_utils.fakebus.FakeBus` (`fakebus.py:130`), just like the real client. |
+| `emitted` list | Test affordance — every `HiveMessage` passed to `emit()` is appended for assertions (`fakebus.py:189`). |
+
+## API surface
+
+| Method | Sync/async | Behaviour |
+|---|---|---|
+| `connect(bus=None, protocol=None, site_id=None)` | async | No-op; sets `connected_event` and `handshake_event`. |
+| `close()` | async | Clears both events. |
+| `wait_for_handshake(timeout, max_retries)` | async | Returns immediately if `handshake_event` is set; otherwise raises after `timeout`. |
+| `emit(message, binary_type=None)` | async | Wraps `MycroftMessage` into `HiveMessageType.BUS`, injects routing context, records in `emitted`, dispatches. |
+| `emit_mycroft(message)` | async | Convenience for the `BUS`-wrap path. |
+| `emit_intercom(message, pubkey)` | async | No encryption; dispatches as `HiveMessageType.INTERCOM`. |
+| `wait_for_message(type, timeout)` | async | `asyncio.Event`-based wait on `emitter`. |
+| `wait_for_payload(payload_type, message_type, timeout)` | async | Same wait, filtered by inner `payload.msg_type`. |
+| `wait_for_mycroft(msg_type, timeout)` | async | Sugar for `wait_for_payload(message_type=BUS)`. |
+| `wait_for_response(message, reply_type=None, timeout)` | async | Emit, then wait. For `MycroftMessage` queries, matches the inner payload type via `HivePayloadWaiter` semantics. |
+| `on`/`once`/`remove`/`on_mycroft` | sync | Routes `HiveMessageType.*` to `emitter`, everything else to the internal Mycroft bus — matches the real `AsyncHiveMessageBusClient` contract. |
+
+## Test affordances
+
+Two attributes make assertions easy:
+
+- **`bus.emitted: list[HiveMessage]`** — every message passed to
+  `emit()`. Assert on counts, types, payloads, and injected routing
+  context.
+- **`bus.emitter`** — the `pyee.EventEmitter`. Inspect listeners,
+  fire synthetic events, drive corner cases.
+
+```python
+await bus.emit(MycroftMessage("speak", {"utterance": "hi"}))
+
+assert len(bus.emitted) == 1
+assert bus.emitted[0].msg_type == HiveMessageType.BUS
+assert bus.emitted[0].payload.context["session"]["session_id"] == "kitchen"
+```
+
+## When **not** to use it
+
+- **Protocol regressions, handshake bugs, encryption changes** — the
+  fake skips all of that. Use `hivescope` (real handshake) or run an
+  integration test against `HiveMind-core`.
+- **Binary payload framing tests** — same reason; `serialization.py`
+  paths are not exercised.
+- **Reconnect semantics** — the fake has no transport to drop.
+
+## Source
+
+- Class: `hivemind_bus_client/fakebus.py`
+- Tests: `tests/test_fakebus.py`

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ client.emit(Message("recognizer_loop:utterance", {"utterances": ["hello world"]}
 - [API Reference](api.md) - `HiveMessage`, `HiveMessageType`, `HiveMessageBusClient`, `BinaryDataCallbacks`, `NodeIdentity`.
 - [Client API](client_api.md) - `HiveMessageBusClient` and `HiveMindHTTPClient` usage.
 - [Async client](async_client.md) - `AsyncHiveMessageBusClient` for asyncio-native applications (FastAPI, aiohttp, async chat bots). Optional: `pip install hivemind-bus-client[async]`.
+- [Fakes](fakebus.md) - `AsyncFakeHiveMessageBus`, the in-process stand-in for `AsyncHiveMessageBusClient` used by tests and embedded scenarios.
 - [Message Types](message_types.md) - `HiveMessage`, `HiveMessageType` enum, routing, serialization.
 - [Binary Serialization](serialization.md) - Bitstring wire format, `get_bitstring`, `decode_bitstring` (reference implementation).
 - [Binary Handlers](binary_handlers.md) - `BinaryDataCallbacks` for TTS audio and file transfers.

--- a/hivemind_bus_client/fakebus.py
+++ b/hivemind_bus_client/fakebus.py
@@ -1,0 +1,305 @@
+"""In-process stand-ins for the HiveMind bus clients.
+
+Currently exposes:
+
+- :class:`AsyncFakeHiveMessageBus` — an asyncio-native fake that mirrors
+  :class:`hivemind_bus_client.async_client.AsyncHiveMessageBusClient`'s
+  public surface without opening a WebSocket or completing a handshake.
+
+The intended consumers are:
+
+1. **Tests** for code that talks to the HiveMind bus via the async client.
+   No need to stand up a HiveMind-core instance or stub the handshake by
+   hand.
+2. **Runtime fallback** wherever a HiveMind client is expected but no
+   server is configured (mirroring how ``ovos_utils.fakebus.FakeBus`` is
+   used as a default-bus today).
+
+A sync ``FakeHiveMessageBus`` could be added here in the future if a
+consumer needs one; today, none does.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Awaitable, Callable, Optional, Union
+
+from ovos_bus_client.message import Message as MycroftMessage
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.log import LOG
+from pyee import EventEmitter
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+
+class AsyncFakeHiveMessageBus:
+    """asyncio-native stand-in for ``AsyncHiveMessageBusClient``.
+
+    Mirrors the real client's surface so consumer code can be tested or
+    embedded without an actual WebSocket connection or a HiveMind-core
+    instance:
+
+    - ``connect``, ``close``, ``emit``, ``wait_for_message``,
+      ``wait_for_payload``, ``wait_for_response``,
+      ``wait_for_handshake``, ``emit_mycroft``, ``emit_intercom`` are
+      coroutines.
+    - ``on``, ``once``, ``remove``, ``on_mycroft`` are synchronous —
+      matches the real client, which uses ``pyee.EventEmitter`` for
+      dispatch and never required awaitable callbacks.
+
+    What's faked vs. what's real:
+
+    - **No WebSocket.** ``connect()`` is a no-op that flips
+      ``connected_event`` and ``handshake_event``. No transport, no
+      retries, no handshake state machine.
+    - **No encryption / serialization.** ``emit()`` dispatches the
+      ``HiveMessage`` (or wrapped Mycroft ``Message``) directly through
+      the emitter; payload framing, AES-GCM, and bitstring serialization
+      are skipped because no wire bytes are produced.
+    - **Real routing-context injection.** For ``HiveMessageType.BUS``
+      messages, ``emit()`` injects the same ``context["source"]``,
+      ``platform``, ``destination``, and ``session`` keys the real
+      client would, so downstream session-aware tests behave identically.
+    - **Real internal-bus dispatch.** Mycroft handlers registered via
+      ``on()`` (when the event name is not a ``HiveMessageType``) attach
+      to a real :class:`ovos_utils.fakebus.FakeBus`, just like the real
+      client.
+
+    Lifecycle::
+
+        bus = AsyncFakeHiveMessageBus()
+        await bus.connect()
+        bus.on(HiveMessageType.BUS, my_handler)
+        await bus.emit(MycroftMessage("speak", {"utterance": "hi"}))
+        reply = await bus.wait_for_response(query, timeout=1.0)
+        await bus.close()
+    """
+
+    def __init__(self,
+                 *,
+                 session_id: str = "fake-hivemind-session",
+                 site_id: str = "fake-site",
+                 useragent: str = "AsyncFakeHiveMessageBus",
+                 internal_bus: Optional[FakeBus] = None):
+        self.session_id = session_id
+        self._site_id = site_id
+        self._useragent = useragent
+        self.emitter = EventEmitter()
+        self.internal_bus = internal_bus or FakeBus()
+        self.connected_event = asyncio.Event()
+        self.handshake_event = asyncio.Event()
+        self.emitted: list[HiveMessage] = []
+        self.crypto_key: Optional[str] = None  # parity attribute; never set
+        # Backwards-compat parity attributes that real client exposes
+        self.compress = False
+        self.binarize = False
+
+    # ------------------------------------------------------------------
+    # identity-shaped properties
+    # ------------------------------------------------------------------
+
+    @property
+    def useragent(self) -> str:
+        return self._useragent
+
+    @useragent.setter
+    def useragent(self, val: str):
+        self._useragent = val
+
+    @property
+    def site_id(self) -> str:
+        return self._site_id
+
+    @site_id.setter
+    def site_id(self, val: str):
+        self._site_id = val
+
+    # ------------------------------------------------------------------
+    # lifecycle (async)
+    # ------------------------------------------------------------------
+
+    async def connect(self, bus=None, protocol=None, site_id: Optional[str] = None):
+        """No-op connect: flips connected_event + handshake_event, registers
+        no transport. ``bus``, ``protocol``, ``site_id`` mirror the real
+        client's signature so call sites are drop-in."""
+        if site_id is not None:
+            self._site_id = site_id
+        if bus is not None:
+            # If caller hands us a "core" bus to bridge into, use it.
+            self.internal_bus = bus
+        self.connected_event.set()
+        self.handshake_event.set()
+        return self
+
+    async def close(self):
+        self.connected_event.clear()
+        self.handshake_event.clear()
+        self.crypto_key = None
+
+    async def wait_for_handshake(self, timeout: float = 5.0, max_retries: int = 15):
+        # Always set in connect(); return immediately.
+        if not self.handshake_event.is_set():
+            try:
+                await asyncio.wait_for(self.handshake_event.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                raise RuntimeError("timed out waiting for handshake")
+
+    # ------------------------------------------------------------------
+    # handler registration (sync — matches real async client)
+    # ------------------------------------------------------------------
+
+    def on(self, event_name: Union[HiveMessageType, str], func: Callable):
+        if event_name not in list(HiveMessageType):
+            # mycroft event → internal bus
+            self.internal_bus.on(event_name, func)
+        else:
+            self.emitter.on(event_name, func)
+
+    def once(self, event_name: Union[HiveMessageType, str], func: Callable):
+        if event_name not in list(HiveMessageType):
+            self.internal_bus.once(event_name, func)
+        else:
+            self.emitter.once(event_name, func)
+
+    def remove(self, event_name: Union[HiveMessageType, str], func: Callable):
+        try:
+            if event_name not in list(HiveMessageType):
+                self.internal_bus.remove(event_name, func)
+            else:
+                self.emitter.remove_listener(event_name, func)
+        except Exception:
+            pass
+
+    def on_mycroft(self, mycroft_msg_type: str, func: Callable):
+        self.internal_bus.on(mycroft_msg_type, func)
+
+    # ------------------------------------------------------------------
+    # emit (async)
+    # ------------------------------------------------------------------
+
+    async def emit(self,
+                   message: Union[MycroftMessage, HiveMessage],
+                   binary_type=None):
+        """Same routing-context injection and dispatch shape as the real
+        client. Records the message in ``self.emitted`` for test assertions.
+        """
+        if isinstance(message, MycroftMessage):
+            message = HiveMessage(msg_type=HiveMessageType.BUS, payload=message)
+
+        # Routing context for BUS messages (same as real client)
+        if message.msg_type == HiveMessageType.BUS:
+            payload = message.payload
+            ctx = payload.context
+            ctx.setdefault("source", self._useragent)
+            ctx.setdefault("platform", self._useragent)
+            ctx.setdefault("destination", "HiveMind")
+            ctx.setdefault("session", {})
+            ctx["session"]["session_id"] = self.session_id
+            ctx["session"]["site_id"] = self._site_id
+            message.payload = payload
+            # surface to internal-bus subscribers
+            self.internal_bus.emit(message.payload)
+
+        self.emitted.append(message)
+        # raw 'message' event (mirror real client)
+        try:
+            self.emitter.emit("message", message.serialize())
+        except Exception:
+            LOG.debug("could not serialize message in fake emit; skipping raw event")
+        # hive-type event
+        self.emitter.emit(message.msg_type, message)
+
+    async def emit_mycroft(self, message: MycroftMessage):
+        await self.emit(
+            HiveMessage(msg_type=HiveMessageType.BUS, payload=message)
+        )
+
+    async def emit_intercom(self, message, pubkey):
+        """Pass-through for INTERCOM emit — no encryption in the fake."""
+        await self.emit(HiveMessage(HiveMessageType.INTERCOM, payload=message))
+
+    # ------------------------------------------------------------------
+    # waiters
+    # ------------------------------------------------------------------
+
+    async def wait_for_message(self,
+                               message_type: Union[HiveMessageType, str],
+                               timeout: float = 3.0) -> Optional[HiveMessage]:
+        evt = asyncio.Event()
+        captured = {"msg": None}
+
+        def _rcv(m):
+            captured["msg"] = m
+            evt.set()
+
+        self.emitter.once(message_type, _rcv)
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        return captured["msg"]
+
+    async def wait_for_payload(self,
+                               payload_type: Union[HiveMessageType, str],
+                               message_type: Union[HiveMessageType, str] = HiveMessageType.THIRDPRTY,
+                               timeout: float = 3.0) -> Optional[HiveMessage]:
+        evt = asyncio.Event()
+        captured = {"msg": None}
+
+        def _rcv(m):
+            if getattr(m.payload, "msg_type", None) == payload_type:
+                captured["msg"] = m
+                evt.set()
+
+        self.emitter.on(message_type, _rcv)
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self.emitter.remove_listener(message_type, _rcv)
+        return captured["msg"]
+
+    async def wait_for_mycroft(self, mycroft_msg_type: str,
+                               timeout: float = 3.0) -> Optional[HiveMessage]:
+        return await self.wait_for_payload(
+            mycroft_msg_type, timeout=timeout,
+            message_type=HiveMessageType.BUS,
+        )
+
+    async def wait_for_response(self,
+                                message: Union[MycroftMessage, HiveMessage],
+                                reply_type: Optional[Union[HiveMessageType, str]] = None,
+                                timeout: float = 3.0) -> Optional[HiveMessage]:
+        message_type = reply_type or message.msg_type
+        evt = asyncio.Event()
+        captured = {"msg": None}
+
+        if isinstance(message, MycroftMessage):
+            # match by inner payload type, like real client's HivePayloadWaiter
+            def _rcv(m):
+                if getattr(m.payload, "msg_type", None) == message_type:
+                    captured["msg"] = m
+                    evt.set()
+            self.emitter.on(HiveMessageType.BUS, _rcv)
+        else:
+            def _rcv(m):
+                captured["msg"] = m
+                evt.set()
+            self.emitter.once(message_type, _rcv)
+
+        await self.emit(message)
+        try:
+            await asyncio.wait_for(evt.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            if isinstance(message, MycroftMessage):
+                try:
+                    self.emitter.remove_listener(HiveMessageType.BUS, _rcv)
+                except Exception:
+                    pass
+        return captured["msg"]
+
+
+__all__ = ["AsyncFakeHiveMessageBus"]

--- a/tests/test_fakebus.py
+++ b/tests/test_fakebus.py
@@ -1,0 +1,276 @@
+"""Tests for AsyncFakeHiveMessageBus.
+
+Mirrors the test shape of ovos_utils.fakebus.AsyncFakeBus and exercises
+the surface of AsyncHiveMessageBusClient without standing up a real
+WebSocket.
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from ovos_bus_client.message import Message as MycroftMessage
+
+from hivemind_bus_client.fakebus import AsyncFakeHiveMessageBus
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestLifecycle(unittest.TestCase):
+    def test_constructs_idle(self):
+        bus = AsyncFakeHiveMessageBus()
+        self.assertFalse(bus.connected_event.is_set())
+        self.assertFalse(bus.handshake_event.is_set())
+
+    def test_connect_sets_both_events(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        self.assertTrue(bus.connected_event.is_set())
+        self.assertTrue(bus.handshake_event.is_set())
+
+    def test_connect_site_id_override(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect(site_id="kitchen"))
+        self.assertEqual(bus.site_id, "kitchen")
+
+    def test_close_clears_events(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        _run(bus.close())
+        self.assertFalse(bus.connected_event.is_set())
+        self.assertFalse(bus.handshake_event.is_set())
+
+    def test_wait_for_handshake_returns_when_set(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        _run(bus.wait_for_handshake(timeout=0.1))
+
+    def test_wait_for_handshake_raises_when_never_set(self):
+        bus = AsyncFakeHiveMessageBus()
+        with self.assertRaises(RuntimeError):
+            _run(bus.wait_for_handshake(timeout=0.05))
+
+
+class TestHandlerRegistration(unittest.TestCase):
+    def setUp(self):
+        self.bus = AsyncFakeHiveMessageBus()
+        _run(self.bus.connect())
+
+    def test_on_hive_event_dispatches(self):
+        seen = []
+        self.bus.on(HiveMessageType.PING, lambda m: seen.append(m))
+        _run(self.bus.emit(HiveMessage(HiveMessageType.PING, {"flood_id": "x"})))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0].msg_type, HiveMessageType.PING)
+
+    def test_on_mycroft_event_dispatches_via_internal_bus(self):
+        seen = []
+        self.bus.on("speak", lambda m: seen.append(m))
+        _run(self.bus.emit(MycroftMessage("speak", {"utterance": "hi"})))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0].msg_type, "speak")
+
+    def test_once_fires_only_once(self):
+        seen = []
+        self.bus.once(HiveMessageType.PING, lambda m: seen.append(m))
+        _run(self.bus.emit(HiveMessage(HiveMessageType.PING)))
+        _run(self.bus.emit(HiveMessage(HiveMessageType.PING)))
+        self.assertEqual(len(seen), 1)
+
+    def test_remove_hive_handler(self):
+        cb = lambda m: None
+        self.bus.on(HiveMessageType.PING, cb)
+        self.bus.remove(HiveMessageType.PING, cb)
+        self.assertEqual(self.bus.emitter.listeners(HiveMessageType.PING), [])
+
+    def test_remove_mycroft_handler(self):
+        cb = lambda m: None
+        self.bus.on("speak", cb)
+        self.bus.remove("speak", cb)
+
+    def test_on_mycroft_alias(self):
+        seen = []
+        self.bus.on_mycroft("recognizer_loop:utterance",
+                            lambda m: seen.append(m))
+        _run(self.bus.emit(MycroftMessage("recognizer_loop:utterance",
+                                          {"utterances": ["hi"]})))
+        self.assertEqual(len(seen), 1)
+
+
+class TestEmitRoutingContext(unittest.TestCase):
+    def test_emit_mycroft_wrapped_into_bus(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        _run(bus.emit(MycroftMessage("speak", {"utterance": "hi"})))
+        self.assertEqual(len(bus.emitted), 1)
+        self.assertEqual(bus.emitted[0].msg_type, HiveMessageType.BUS)
+        self.assertEqual(bus.emitted[0].payload.msg_type, "speak")
+
+    def test_emit_injects_routing_context(self):
+        bus = AsyncFakeHiveMessageBus(
+            session_id="sess-1", site_id="kitchen", useragent="bridge-X",
+        )
+        _run(bus.connect())
+        _run(bus.emit(MycroftMessage("speak", {"u": "hi"})))
+        payload = bus.emitted[0].payload
+        self.assertEqual(payload.context["source"], "bridge-X")
+        self.assertEqual(payload.context["destination"], "HiveMind")
+        self.assertEqual(payload.context["session"]["session_id"], "sess-1")
+        self.assertEqual(payload.context["session"]["site_id"], "kitchen")
+
+    def test_emit_records_in_emitted_list(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        _run(bus.emit(HiveMessage(HiveMessageType.PING, {"flood_id": "a"})))
+        _run(bus.emit(HiveMessage(HiveMessageType.PING, {"flood_id": "b"})))
+        self.assertEqual(len(bus.emitted), 2)
+
+
+class TestWaitForMessage(unittest.TestCase):
+    def test_returns_matched(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            async def feed():
+                await asyncio.sleep(0.02)
+                await bus.emit(HiveMessage(HiveMessageType.PING,
+                                           {"flood_id": "x"}))
+            asyncio.create_task(feed())
+            return await bus.wait_for_message(HiveMessageType.PING, timeout=1.0)
+
+        got = _run(scenario())
+        self.assertIsNotNone(got)
+        self.assertEqual(got.msg_type, HiveMessageType.PING)
+
+    def test_returns_none_on_timeout(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            return await bus.wait_for_message(HiveMessageType.PING, timeout=0.05)
+
+        self.assertIsNone(_run(scenario()))
+
+
+class TestWaitForResponse(unittest.TestCase):
+    def test_mycroft_response_matches_inner_msg_type(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            def echo(m: HiveMessage):
+                # respond as a BUS HiveMessage carrying a Mycroft reply
+                asyncio.create_task(
+                    bus.emit(MycroftMessage(
+                        "speak",
+                        {"utterance": "ok"},
+                        m.payload.context,
+                    ))
+                )
+            bus.on(HiveMessageType.BUS, echo)
+            return await bus.wait_for_response(
+                MycroftMessage("speak", {"utterance": "hello"}),
+                reply_type="speak",
+                timeout=1.0,
+            )
+
+        reply = _run(scenario())
+        self.assertIsNotNone(reply)
+        self.assertEqual(reply.msg_type, HiveMessageType.BUS)
+        self.assertEqual(reply.payload.msg_type, "speak")
+
+    def test_hive_response_returns_first_match(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            def echo(_m):
+                asyncio.create_task(
+                    bus.emit(HiveMessage(HiveMessageType.PING, {"flood_id": "r"}))
+                )
+            bus.on(HiveMessageType.PING, echo)
+            return await bus.wait_for_response(
+                HiveMessage(HiveMessageType.PING, {"flood_id": "q"}),
+                timeout=1.0,
+            )
+
+        reply = _run(scenario())
+        self.assertIsNotNone(reply)
+        self.assertEqual(reply.msg_type, HiveMessageType.PING)
+
+    def test_returns_none_on_timeout(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            # Distinct reply_type so the emit doesn't trigger its own waiter.
+            return await bus.wait_for_response(
+                HiveMessage(HiveMessageType.PING),
+                reply_type=HiveMessageType.CASCADE,
+                timeout=0.05,
+            )
+
+        self.assertIsNone(_run(scenario()))
+
+
+class TestWaitForPayloadAndMycroft(unittest.TestCase):
+    def test_wait_for_payload_filters_inner(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            async def feed():
+                await asyncio.sleep(0.02)
+                # wrong inner type — ignored
+                await bus.emit(
+                    HiveMessage(HiveMessageType.BUS,
+                                payload=MycroftMessage("not-speak"))
+                )
+                await asyncio.sleep(0.02)
+                # right inner type — matched
+                await bus.emit(
+                    HiveMessage(HiveMessageType.BUS,
+                                payload=MycroftMessage("speak",
+                                                       {"utterance": "ok"}))
+                )
+            asyncio.create_task(feed())
+            return await bus.wait_for_payload(
+                "speak",
+                message_type=HiveMessageType.BUS,
+                timeout=1.0,
+            )
+
+        got = _run(scenario())
+        self.assertIsNotNone(got)
+        self.assertEqual(got.payload.msg_type, "speak")
+
+    def test_wait_for_mycroft_is_payload_with_bus_default(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+
+        async def scenario():
+            async def feed():
+                await asyncio.sleep(0.02)
+                await bus.emit(MycroftMessage("speak", {"u": "ok"}))
+            asyncio.create_task(feed())
+            return await bus.wait_for_mycroft("speak", timeout=1.0)
+
+        got = _run(scenario())
+        self.assertIsNotNone(got)
+        self.assertEqual(got.payload.msg_type, "speak")
+
+
+class TestEmitIntercom(unittest.TestCase):
+    def test_intercom_passes_through(self):
+        bus = AsyncFakeHiveMessageBus()
+        _run(bus.connect())
+        _run(bus.emit_intercom({"payload": "anything"}, pubkey="ignored"))
+        self.assertEqual(bus.emitted[0].msg_type, HiveMessageType.INTERCOM)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an in-process stand-in for `AsyncHiveMessageBusClient`. Same role as `ovos_utils.fakebus.AsyncFakeBus` plays on the OVOS side: lightweight fake for tests of code that talks to the HiveMind bus via the async client, plus runtime fallback wherever a client is expected but no server is configured.

This is the prep work for the upcoming `HiveMind-deltachat-bridge` async migration — that PR will use `AsyncFakeHiveMessageBus` for its test suite.

## Why here and not in hivescope

Both are reasonable homes; here's the reasoning for keeping the fake in `hivemind-bus-client.fakebus`:

| Layer | OVOS side | HiveMind side |
|---|---|---|
| Real client | `ovos-bus-client` → `MessageBusClient`, `AsyncMessageBusClient` | `hivemind-bus-client` → `HiveMessageBusClient`, `AsyncHiveMessageBusClient` |
| **Low-level in-process fakes** | `ovos-utils` → `FakeBus`, `AsyncFakeBus` | **`hivemind-bus-client` → `AsyncFakeHiveMessageBus`** (this PR) |
| E2E test harness | `ovoscope` | `hivescope` |

`hivescope` already imports `ovos_utils.fakebus.FakeBus` at `topology.py:32`, `plugins/agent.py:22`, `node.py:14` — it uses the low-level fakes as building blocks, not as its public API. By the same logic, `AsyncFakeHiveMessageBus` belongs next to the client it fakes; `hivescope` can build on it.

Dependency direction matters here: any consumer that wants to mock the async client (the upcoming `deltachat-bridge` migration; future async chat-bot integrations; anything embedding the client) should be able to do so without installing `hivescope`, which pulls in `HiveMind-core` and the full topology stack.

## What's new

### `hivemind_bus_client/fakebus.py`

- **`AsyncFakeHiveMessageBus`** mirrors `AsyncHiveMessageBusClient`'s surface:
  - `connect` / `close` / `emit` / `wait_for_message` / `wait_for_payload` / `wait_for_mycroft` / `wait_for_response` / `wait_for_handshake` / `emit_mycroft` / `emit_intercom` are coroutines.
  - `on` / `once` / `remove` / `on_mycroft` stay synchronous (matches the real client's `pyee`-backed contract).

What's faked vs. what's real:

- **WebSocket / handshake**: none. `connect()` is a no-op that flips `connected_event` and `handshake_event`.
- **Encryption / binary framing**: skipped — emit dispatches the `HiveMessage` directly through the emitter.
- **`HiveMessageType.BUS` routing-context injection**: **real** — `source`, `platform`, `destination`, `session` keys identical to the real client, so session-aware downstream tests behave identically.
- **Mycroft handler dispatch**: **real** — attaches to a real `ovos_utils.fakebus.FakeBus` via `internal_bus`, just like the real client.
- **`emitted` list** as a test affordance — every `HiveMessage` passed to `emit()` is appended for assertions.

### Tests — `tests/test_fakebus.py` (23 new, all passing)

- Lifecycle: idle / `connect` / `close` / `wait_for_handshake` timeout paths.
- Handler registration: `on` / `once` / `remove` for both hive and mycroft event types; `on_mycroft` alias.
- `emit`: Mycroft → BUS wrapping, routing-context injection, `emitted` recording.
- `wait_for_message` / `wait_for_payload` / `wait_for_mycroft` / `wait_for_response` — including the `MycroftMessage` payload-waiter path.
- `emit_intercom` passthrough.

Full suite: **322 passed, 4 skipped**, no regressions.

### Docs

- `docs/fakebus.md` — purpose, quick start, what's faked vs real, full API table, test affordances, "when not to use it" callout pointing to hivescope.
- `docs/index.md` — links the new doc.

## Test plan

- [x] 23 new unit tests pass.
- [x] Full suite unchanged (322 + 4 skipped).
- [ ] First downstream use: `HiveMind-deltachat-bridge` async migration (next PR) will exercise this fake in its test suite.
- [ ] CI green across the supported Python matrix.

Refs:
- This package's PR #115 (`AsyncHiveMessageBusClient`, 0.8.0a1).
- OpenVoiceOS/ovos-utils PR #371 (`AsyncFakeBus`, the OVOS sibling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-process asyncio-native fake HiveMind message bus client for development and testing, eliminating WebSocket and handshake overhead.

* **Documentation**
  * Added comprehensive guide covering usage examples, API reference, real vs. fake behavior comparison, and appropriate use cases.

* **Tests**
  * Added full test coverage for lifecycle management, event routing, message emission, and response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-websocket-client/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->