### PR TITLE
build: bump stale OVOS dep floors to the modern major

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,5 +13,5 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       # hivescope is required by tests/e2e/
-      pre_install_pip: '"hivescope @ git+https://github.com/JarbasHiveMind/hivescope@dev"'
+      pre_install_pip: '"hivescope==0.3.0a1"'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'hivemind_bus_client'
+      install_extras: 'test'
       test_path: 'tests/'
-      pre_install_pip: '"hivescope @ git+https://github.com/JarbasHiveMind/hivescope@dev"'
+      pre_install_pip: '"hivescope==0.3.0a1"'
       min_coverage: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "poorman-handshake>=1.0.0,<2.0.0",
-    "ovos_bus_client>=0.0.6a19",
-    "ovos_utils>=0.0.38",
+    "ovos_bus_client>=1.0.0,<2.0.0",
+    "ovos_utils>=0.3.0",
     "bitstring>=4.1.1",
     "cryptography>=41.0.1",
     "pycryptodomex>=3.18.0",
@@ -50,7 +50,7 @@ benchmark = [
 asyncio_mode = "auto"
 
 [project.urls]
-Homepage = "https://github.com/JarbasHiveMind/hivemind_websocket_client"
+Homepage = "https://github.com/JarbasHiveMind/hivemind-websocket-client"
 
 [project.scripts]
 hivemind-client = "hivemind_bus_client.scripts:hmclient_cmds"


### PR DESCRIPTION
The `ovos_bus_client>=0.0.6a19` / `ovos_utils>=0.0.38` floors were ancient — the same stale-floor class that made a downstream client resolve an incompatible old `ovos-bus-client`. Bumps to `ovos_bus_client>=1.0.0,<2.0.0` and `ovos_utils>=0.3.0` (the library uses only standard Message/MessageBusClient/Session APIs present in 1.x; 326 unit tests pass). Also fixes the homepage URL slug to the hyphenated repo name.