### PR TITLE
ci: fix broken coverage job (async tests need pytest-asyncio)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,6 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'hivemind_bus_client'
-      install_extras: 'test'
       test_path: 'tests/'
-      pre_install_pip: '"hivescope==0.3.0a1"'
+      pre_install_pip: '"hivescope==0.3.0a1" pytest-asyncio'
       min_coverage: 0


### PR DESCRIPTION
The coverage job on dev fails: `install_extras: 'test'` triggers gh-automations' buggy literal `pip install test` (no such package), and without it the async client tests have no `pytest-asyncio`. Drops install_extras and installs pytest-asyncio via pre_install_pip. (This fix was stranded on the squash-merged #120 branch.)