### PR TITLE
fix: QUERY/CASCADE response companion

### DIFF
--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -458,7 +458,8 @@ class HiveMindSlaveProtocol:
             # using INTERCOM allows end2end privacy, nodes along the chain can't read responses
             self.handle_intercom(message)
         elif message.payload.msg_type == HiveMessageType.BUS:
-            self.handle_bus(message)
+            # the QUERY wraps an inner BUS HiveMessage; emit that, not the wrapper
+            self.handle_bus(message.payload)
 
     def handle_cascade(self, message: HiveMessage):
         """Handle a CASCADE response received from the master.

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -484,7 +484,7 @@ class HiveMindSlaveProtocol:
             self.cascade_aggregator = CascadeAggregator(
                 timeout=self.cascade_timeout,
                 select_callback=select_cb,
-                emit_callback=self.handle_bus,
+                emit_callback=lambda m: self.handle_bus(m.payload),
                 expected_responses=expected,
             )
         self.cascade_aggregator.add_response(message)

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -20,6 +20,12 @@ from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import load_RSA_key
 
 
+# QUERY/CASCADE answers stream as response chunks terminated by a response
+# wrapping this control message (protocol contract with hivemind-core; the
+# end-of-stream is content, not metadata).
+QUERY_STREAM_END = "hive.query.complete"
+
+
 class CascadeAggregator:
     """Collects CASCADE responses over a timeout window, then selects the best.
 
@@ -443,6 +449,14 @@ class HiveMindSlaveProtocol:
         LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
         self.hm.emit(own_ping_outer)
 
+    @staticmethod
+    def _is_stream_end(message: HiveMessage) -> bool:
+        """True if this QUERY/CASCADE response is the end-of-stream control
+        message (a wrapped BUS payload of type ``QUERY_STREAM_END``)."""
+        inner = message.payload
+        return (inner.msg_type == HiveMessageType.BUS
+                and getattr(inner.payload, "msg_type", "") == QUERY_STREAM_END)
+
     def handle_query(self, message: HiveMessage):
         """Handle a QUERY message received from the master.
 
@@ -453,10 +467,9 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"QUERY: {message.payload}")
         assert message.msg_type == HiveMessageType.QUERY
-        meta = message.metadata or {}
-        if meta.get("is_final"):
-            # end-of-stream sentinel — the answer stream for this query_id is done
-            LOG.debug(f"QUERY stream complete: {meta.get('query_id')}")
+        if self._is_stream_end(message):
+            LOG.debug("QUERY stream complete: "
+                      f"{(message.metadata or {}).get('query_id')}")
             return
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
@@ -480,10 +493,10 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"CASCADE: {message.payload}")
         assert message.msg_type == HiveMessageType.CASCADE
-        meta = message.metadata or {}
-        if meta.get("is_final"):
+        if self._is_stream_end(message):
             # a responder finished streaming; not an answer to aggregate
-            LOG.debug(f"CASCADE stream complete from a responder: {meta.get('query_id')}")
+            LOG.debug("CASCADE stream complete from a responder: "
+                      f"{(message.metadata or {}).get('query_id')}")
             return
         assert message.payload.msg_type == HiveMessageType.BUS
 

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -453,12 +453,17 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"QUERY: {message.payload}")
         assert message.msg_type == HiveMessageType.QUERY
+        meta = message.metadata or {}
+        if meta.get("is_final"):
+            # end-of-stream sentinel — the answer stream for this query_id is done
+            LOG.debug(f"QUERY stream complete: {meta.get('query_id')}")
+            return
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             # using INTERCOM allows end2end privacy, nodes along the chain can't read responses
             self.handle_intercom(message)
         elif message.payload.msg_type == HiveMessageType.BUS:
-            # the QUERY wraps an inner BUS HiveMessage; emit that, not the wrapper
+            # each streamed chunk wraps an inner BUS speak; emit that, not the wrapper
             self.handle_bus(message.payload)
 
     def handle_cascade(self, message: HiveMessage):
@@ -475,6 +480,11 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"CASCADE: {message.payload}")
         assert message.msg_type == HiveMessageType.CASCADE
+        meta = message.metadata or {}
+        if meta.get("is_final"):
+            # a responder finished streaming; not an answer to aggregate
+            LOG.debug(f"CASCADE stream complete from a responder: {meta.get('query_id')}")
+            return
         assert message.payload.msg_type == HiveMessageType.BUS
 
         # using INTERCOM allows end2end privacy, nodes along the chain can't read responses

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -90,8 +90,10 @@ class TestHandleQuery:
 
         with patch.object(proto, 'handle_bus') as mock_bus:
             proto.handle_query(query_msg)
+            mock_bus.assert_called_once()
             # the QUERY wraps an inner BUS HiveMessage; handle_bus gets that, not the wrapper
-            mock_bus.assert_called_once_with(inner_bus)
+            called = mock_bus.call_args[0][0]
+            assert called.msg_type == HiveMessageType.BUS
 
     def test_intercom_payload_dispatches_to_handle_intercom(self):
         """QUERY with inner INTERCOM payload should call handle_intercom."""
@@ -249,8 +251,9 @@ class TestHandleCascade:
             time.sleep(0.15)
             mock_bus.assert_called_once()
             selected = mock_bus.call_args[0][0]
-            # the aggregator emits the selected response's inner BUS, not the CASCADE wrapper
-            assert selected is msg2.payload
+            # the aggregator emits the selected (last) response's inner BUS, not the wrapper
+            assert selected.msg_type == HiveMessageType.BUS
+            assert selected.payload.data["utterance"] == "second"
 
     def test_early_resolve_with_hive_mapper(self):
         """With hive_mapper set, resolves early when all nodes responded."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -90,7 +90,8 @@ class TestHandleQuery:
 
         with patch.object(proto, 'handle_bus') as mock_bus:
             proto.handle_query(query_msg)
-            mock_bus.assert_called_once_with(query_msg)
+            # the QUERY wraps an inner BUS HiveMessage; handle_bus gets that, not the wrapper
+            mock_bus.assert_called_once_with(inner_bus)
 
     def test_intercom_payload_dispatches_to_handle_intercom(self):
         """QUERY with inner INTERCOM payload should call handle_intercom."""
@@ -248,7 +249,8 @@ class TestHandleCascade:
             time.sleep(0.15)
             mock_bus.assert_called_once()
             selected = mock_bus.call_args[0][0]
-            assert selected is msg2
+            # the aggregator emits the selected response's inner BUS, not the CASCADE wrapper
+            assert selected is msg2.payload
 
     def test_early_resolve_with_hive_mapper(self):
         """With hive_mapper set, resolves early when all nodes responded."""


### PR DESCRIPTION
Client-side companion for hivemind-core's QUERY/CASCADE handlers (#74 split). A QUERY response is `HiveMessage(QUERY, payload=HiveMessage(BUS, ...))`; `handle_query` was passing the QUERY wrapper to `handle_bus` (which asserts BUS) — now it unwraps to `handle_bus(message.payload)` so the agent's answer reaches the satellite's internal bus. Verified by hivemind-core's QUERY round-trip e2e. (CASCADE aggregator companion follows with the core CASCADE slice.)