### PR TITLE
docs: zero-to-hero README + library guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,92 +2,344 @@
 
 # HiveMind Bus Client
 
-Python client library for [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) — the primary library for building HiveMind satellites.
+`hivemind-websocket-client` (package `hivemind_bus_client`) is the **foundation library** for every HiveMind satellite. It provides an authenticated, encrypted WebSocket client that extends the standard OVOS bus client, enabling secure and routed communication between a satellite and a [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub.
 
-Extends the standard OVOS bus client with secure, encrypted, routed communication across a HiveMind mesh network. See the [whitepaper](https://github.com/JarbasHiveMind/HiveMind-core/blob/dev/docs/whitepaper.md) for protocol details.
+All satellite packages — `hivemind-mic-satellite`, `HiveMind-voice-relay`, `HiveMind-voice-sat`, and `HiveMind-cli` — build on this library. If you are building a custom satellite or integration, this is your starting point.
+
+## Where it fits in the satellite spectrum
+
+HiveMind satellites are differentiated by how much audio and language processing happens locally. `hivemind-websocket-client` sits below all of them:
+
+| Satellite | Local processing | Remote processing |
+|---|---|---|
+| `HiveMind-cli` | nothing (text input) | everything |
+| `hivemind-mic-satellite` | mic + VAD | STT, TTS, intent, skills |
+| `HiveMind-voice-relay` | mic + VAD + wakeword | STT, TTS |
+| `HiveMind-voice-sat` | mic + VAD + wakeword + STT + TTS | skills only |
+| **This library** | WebSocket transport + encryption | — |
+
+Every satellite in that table uses `HiveMessageBusClient` from this library to open the connection, complete the handshake, and exchange `HiveMessage` packets with the hub. Server-side STT and TTS are provided by the hub's `hivemind-audio-binary-protocol` plugin; the satellite cannot choose the engine — the hub operator configures it.
+
+See the [whitepaper](https://github.com/JarbasHiveMind/HiveMind-core/blob/dev/docs/whitepaper.md) for protocol details.
+
+## Hardware and OS requirements
+
+- Python 3.9 or later
+- No special hardware required — runs on any machine with network access to the hub
+- The async client (`hivemind-bus-client[async]`) requires Python 3.10+
 
 ## Install
 
 ```bash
-uv pip install hivemind_bus_client
+pip install hivemind_bus_client
 ```
 
-## Quick Start
+Async client (asyncio-native applications):
+
+```bash
+pip install "hivemind_bus_client[async]"
+```
+
+Verify:
+
+```bash
+hivemind-client --help
+```
+
+## Quickstart: pair with a hub and send your first message
+
+### 1. Generate an access key on the hub
+
+On the machine running `hivemind-core`:
+
+```bash
+hivemind-core add-client --name "my-satellite" --access-key KEY --password PASS
+```
+
+`add-client` prints an **access key** and a **password**. Keep both — you need them on every satellite you pair.
+
+### 2. Configure the satellite
+
+On the satellite machine:
+
+```bash
+hivemind-client set-identity \
+  --key   "your-access-key" \
+  --password "your-password" \
+  --host  ws://192.168.1.10 \
+  --port  5678 \
+  --siteid living-room
+```
+
+Credentials are saved to `~/.config/hivemind/_identity.json` and are read automatically by the client.
+
+### 3. Verify connectivity
+
+```bash
+hivemind-client ping --host ws://192.168.1.10 --port 5678
+```
+
+### 4. Open a terminal session
+
+```bash
+hivemind-client terminal
+```
+
+Type an utterance, and the hub processes it. Spoken responses are printed to stdout.
+
+### 5. Use the library
 
 ```python
 from hivemind_bus_client import HiveMessageBusClient
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from ovos_bus_client.message import Message
 
-client = HiveMessageBusClient(host="ws://localhost", port=5678)
+# Credentials are loaded from the identity file set in step 2.
+# Pass them explicitly if you prefer:
+#   client = HiveMessageBusClient(key="...", password="...", host="ws://192.168.1.10", port=5678)
+client = HiveMessageBusClient()
 client.connect()
 
-client.on_mycroft("speak", lambda msg: print(msg.data["utterance"]))
+# React to spoken responses from the hub
+client.on_mycroft("speak", lambda msg: print("Hub says:", msg.data["utterance"]))
 
-client.emit(HiveMessage(HiveMessageType.BUS,
-                        Message("recognizer_loop:utterance",
-                                {"utterances": ["hello world"]})))
+# Send an utterance
+client.emit(HiveMessage(
+    HiveMessageType.BUS,
+    Message("recognizer_loop:utterance", {"utterances": ["hello world"]}),
+))
+
+# Block until you're done
+input("Press Enter to disconnect...\n")
+client.close()
 ```
 
-## Message Types
+## Library guide
+
+### Connecting
+
+`HiveMessageBusClient` extends `ovos_bus_client.MessageBusClient`. The constructor accepts credentials either directly or through a saved `NodeIdentity`.
+
+```python
+from hivemind_bus_client import HiveMessageBusClient
+
+# All parameters optional if identity file is populated
+client = HiveMessageBusClient(
+    key="access-key",           # access key from hivemind-core add-client
+    password="password",        # password from hivemind-core add-client
+    host="ws://192.168.1.10",   # hub address, ws:// or wss://
+    port=5678,                  # default 5678
+    useragent="my-satellite",   # shown in hub logs
+    self_signed=True,           # accept self-signed TLS certs
+    share_bus=False,            # share the local OVOS bus with the hub (trusted satellites only)
+    compress=True,              # zlib-compress binary frames
+    binarize=True,              # use binary wire format instead of JSON
+)
+client.connect()                # blocks until the handshake completes
+```
+
+`connect()` runs the WebSocket in a background thread and calls `wait_for_handshake()`. After it returns the connection is live.
+
+### Sending messages
+
+Any OVOS `Message` can be sent directly — the client wraps it in a `HiveMessage(BUS, ...)` automatically:
+
+```python
+from ovos_bus_client.message import Message
+
+client.emit(Message("recognizer_loop:utterance", {"utterances": ["what time is it"]}))
+```
+
+For explicit HiveMessage control:
+
+```python
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+client.emit(HiveMessage(HiveMessageType.BUS,
+                        Message("recognizer_loop:utterance", {"utterances": ["what time is it"]})))
+```
+
+### Receiving messages
+
+Register handlers for OVOS (inner) message types:
+
+```python
+client.on_mycroft("speak", lambda msg: print(msg.data["utterance"]))
+client.on_mycroft("ovos.common_play.play", handle_play)
+```
+
+Register handlers for HiveMind protocol messages:
+
+```python
+from hivemind_bus_client.message import HiveMessageType
+
+client.on(HiveMessageType.BROADCAST, lambda hm: print("Broadcast:", hm.payload))
+client.on(HiveMessageType.PING, lambda hm: print("Ping from", hm.metadata))
+```
+
+### Wait helpers
+
+```python
+# Send and block until a reply arrives
+response = client.wait_for_response(
+    Message("recognizer_loop:utterance", {"utterances": ["what time is it"]}),
+    reply_type="speak",
+    timeout=10,
+)
+if response:
+    print(response.payload.data["utterance"])
+
+# Wait for the next message of a given HiveMind type
+hive_msg = client.wait_for_message(HiveMessageType.BROADCAST, timeout=30)
+
+# Wait for the next inner OVOS message of a given type wrapped in BUS
+bus_msg = client.wait_for_mycroft("speak", timeout=10)
+```
+
+### ESCALATE, QUERY, CASCADE, BROADCAST, PROPAGATE
+
+```python
+# ESCALATE — forward up the authority chain (supervisor hubs)
+client.emit(HiveMessage(HiveMessageType.ESCALATE,
+                        Message("recognizer_loop:utterance", {"utterances": ["call admin"]})))
+
+# QUERY — first answering node wins
+inner = HiveMessage(HiveMessageType.BUS,
+                    Message("intent.request", {"utterance": "what time is it"}))
+client.emit(HiveMessage(HiveMessageType.QUERY, payload=inner))
+
+# BROADCAST — admin pushes to all connected satellites (requires admin access key)
+client.emit(HiveMessage(
+    HiveMessageType.BROADCAST,
+    payload=HiveMessage(HiveMessageType.BUS,
+                        Message("speak", {"utterance": "System update in 5 minutes"}))
+))
+```
+
+### Peer-to-peer encrypted messages (INTERCOM)
+
+INTERCOM uses hybrid encryption (random AES-256-GCM key per message, RSA-encrypted key exchange):
+
+```python
+target_pubkey = "-----BEGIN PUBLIC KEY-----\n..."
+client.emit_intercom(
+    HiveMessage(HiveMessageType.BUS, Message("speak", {"utterance": "private message"})),
+    pubkey=target_pubkey,
+)
+```
+
+Incoming INTERCOM messages are only injected into the internal bus if the sender's public key is in `NodeIdentity.trusted_keys`.
+
+### Async client
+
+For asyncio-native applications (FastAPI, aiohttp, async chat bots):
+
+```python
+from hivemind_bus_client import AsyncHiveMessageBusClient
+
+async def main():
+    client = AsyncHiveMessageBusClient(key="...", password="...", host="ws://192.168.1.10")
+    await client.connect()
+    await client.emit(Message("recognizer_loop:utterance", {"utterances": ["hello"]}))
+```
+
+Requires: `pip install "hivemind_bus_client[async]"`
+
+### Binary payloads (TTS audio, files)
+
+Override `BinaryDataCallbacks` to handle incoming binary data:
+
+```python
+from hivemind_bus_client.client import BinaryDataCallbacks, HiveMessageBusClient
+
+class MyCallbacks(BinaryDataCallbacks):
+    def handle_receive_tts(self, bin_data: bytes, utterance: str, lang: str, file_name: str):
+        with open(file_name, "wb") as f:
+            f.write(bin_data)
+
+client = HiveMessageBusClient(bin_callbacks=MyCallbacks())
+client.connect()
+```
+
+## Message types
 
 | Type | Direction | Description |
-|------|-----------|-------------|
-| `BUS` | satellite ↔ master | Standard AI bus message |
-| `ESCALATE` | upstream | Forward up the authority chain |
+|---|---|---|
+| `BUS` | satellite ↔ hub | Standard OVOS bus message forwarded to the hub's skill engine |
+| `ESCALATE` | upstream | Forward up the authority chain (supervisor hubs) |
 | `QUERY` | upstream + response | First answering node wins |
-| `BROADCAST` | downstream | Admin pushes to all satellites |
+| `BROADCAST` | downstream | Admin pushes to all connected satellites |
 | `PROPAGATE` | flood | Forward to all peers in all directions |
 | `CASCADE` | flood + responses | Collect answers from all nodes |
 | `INTERCOM` | any → any | End-to-end hybrid-encrypted (AES-GCM + RSA) |
 | `PING` | inside PROPAGATE | Flood-based network topology discovery |
+| `BINARY` | hub → satellite | Raw binary payload (TTS audio, file transfer) |
 
 ## Security
 
-- **Per-link encryption**: AES-GCM or ChaCha20-Poly1305, negotiated at handshake
-- **Hybrid INTERCOM encryption**: Random AES-256 key per message, RSA-encrypted key exchange
-- **Trusted peers**: `NodeIdentity.trusted_keys` gates BUS injection for PROPAGATE and INTERCOM from untrusted peers
-- **Topology-as-policy**: Network structure determines access control (see whitepaper §4)
+- **Per-link encryption**: AES-GCM or ChaCha20-Poly1305, negotiated at handshake via `poorman_handshake`
+- **Hybrid INTERCOM encryption**: Random AES-256 key per message, RSA-encrypted key exchange — no payload size limit
+- **Self-signed TLS**: `self_signed=True` (default) accepts self-signed certificates; set `False` in production
+- **Trusted peers**: Only peers with a public key in `NodeIdentity.trusted_keys` can inject BUS messages via PROPAGATE and INTERCOM; untrusted messages are silently dropped
 
-## Trusted Keys
+## Identity and credentials
 
 ```python
 from hivemind_bus_client.identity import NodeIdentity
 
-identity = NodeIdentity()
-identity.add_trusted_key("living-room-hub", "<RSA_PUBLIC_KEY>")
+identity = NodeIdentity()            # loads from ~/.config/hivemind/_identity.json
+print(identity.access_key)
+print(identity.default_master)
+
+identity.add_trusted_key("home-hub", "-----BEGIN PUBLIC KEY-----\n...")
 identity.save()
 ```
 
-Untrusted PROPAGATE(BUS) and INTERCOM messages are silently dropped.
-
-## CASCADE Response Aggregation
-
-CASCADE collects responses from all reachable nodes via `CascadeAggregator`:
-
-```python
-proto.cascade_select_callback = lambda responses: responses[0]  # pick best
-proto.hive_mapper = mapper  # enables early resolution when all nodes answered
-```
+See [Identity & Credentials](docs/identity.md) for the full field reference.
 
 ## CLI
 
 ```bash
-hivemind-client set-identity --key KEY --password PASS --siteid SITE
-hivemind-client terminal --host ws://hub.local --port 5678
+# Persist credentials
+hivemind-client set-identity --key KEY --password PASS --host ws://hub.local --port 5678 --siteid home
+
+# Interactive terminal (type utterances, see spoken responses)
+hivemind-client terminal
+
+# Ping the hub and print round-trip info
 hivemind-client ping --host ws://hub.local --port 5678
-hivemind-client send-mycroft --msg "recognizer_loop:utterance" --payload '{"utterances": ["hello"]}'
+
+# Send a single OVOS message
+hivemind-client send-mycroft \
+  --msg "recognizer_loop:utterance" \
+  --payload '{"utterances": ["hello world"]}'
+
+# Send as ESCALATE or PROPAGATE
 hivemind-client escalate --msg "recognizer_loop:utterance" --payload '{"utterances": ["hello"]}'
 hivemind-client propagate --msg "recognizer_loop:utterance" --payload '{"utterances": ["hello"]}'
 ```
 
+## Troubleshooting
+
+**`RuntimeError: NodeIdentity not set`** — Run `hivemind-client set-identity` or pass `key`, `password`, and `host` to the constructor.
+
+**`RuntimeError: timed out waiting for handshake`** — The hub is unreachable or the port is wrong. Verify the hub is running (`hivemind-core listen`) and the firewall allows port 5678. Try `hivemind-client ping` first.
+
+**`got encrypted message, but could not decrypt!`** — The access key or password does not match what was registered on the hub. Re-run `hivemind-core add-client` and update the satellite identity.
+
+**Connection drops immediately** — The hub may have rejected the access key (wrong key, key revoked, or blacklisted). Check hub logs: `journalctl -u hivemind-core -f`.
+
 ## Documentation
 
-Full docs in [`/docs`](docs/index.md):
+Full reference in [`/docs`](docs/index.md):
 
+- [Installation](docs/installation.md) — PyPI, optional extras, dependencies
 - [API Reference](docs/api.md) — `HiveMessage`, `HiveMessageBusClient`, `NodeIdentity`, `HiveMapper`
+- [Client API](docs/client_api.md) — WebSocket and HTTP client usage
+- [Async Client](docs/async_client.md) — asyncio-native `AsyncHiveMessageBusClient`
 - [Message Types](docs/message_types.md) — Routing modes, QUERY, CASCADE, PING
-- [Identity & Trust](docs/identity.md) — Credentials, RSA keys, trusted peers
-- [Examples](docs/examples.md) — Chat, TTS, INTERCOM, QUERY, CASCADE, trust management
-- [CLI Guide](docs/cli_guide.md) — Terminal, ping, send commands
+- [Identity & Credentials](docs/identity.md) — Credentials, RSA keys, trusted peers
+- [Binary Handlers](docs/binary_handlers.md) — TTS audio and file transfer callbacks
 - [Serialization](docs/serialization.md) — Binary wire format
+- [CLI Reference](docs/cli.md) — All `hivemind-client` commands
+- [Examples](docs/examples.md) — Chat, TTS, INTERCOM, QUERY, CASCADE, trust management

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,26 +120,6 @@ Trusted keys are stored as an alias → public key mapping in the identity file.
 
 ---
 
-## `HiveMindSlaveProtocol` (`hivemind_bus_client/protocol.py:164`)
-
-Protocol handler used by `HiveMessageBusClient` to dispatch incoming `HiveMessage` objects to the appropriate handler based on `msg_type`. Every handler asserts the message type at entry and fails loudly on misrouted messages.
-
-### Public Handler Methods
-
-| Method | Asserted `msg_type` | Notes | Source |
-|--------|---------------------|-------|--------|
-| `handle_hello(message)` | `HELLO` | Session sync at connect time | `protocol.py:220` |
-| `handle_handshake(message)` | `HANDSHAKE` | Key exchange at connect time | `protocol.py:273` |
-| `handle_bus(message)` | `BUS` | Dispatches inner `MycroftMessage` to the internal bus | `protocol.py:337` |
-| `handle_broadcast(message)` | `BROADCAST` | Inner payload must be `BUS` or `INTERCOM`; passes `message.payload` to `handle_bus` or `handle_intercom` | `protocol.py:356` |
-| `handle_propagate(message)` | `PROPAGATE` | Inner payload must be `BUS`, `INTERCOM`, or `PING`; passes `message.payload` to the appropriate handler | `protocol.py:377` |
-| `handle_ping(message)` | `PING` | Receives the **inner PING directly** (not the outer PROPAGATE wrapper); flood-loop prevention via `HiveMapper.check_flood_id` | `protocol.py:404` |
-| `handle_query(message)` | `QUERY` | Inner payload must be `BUS` or `INTERCOM` | `protocol.py:446` |
-| `handle_cascade(message)` | `CASCADE` | Buffers responses in `CascadeAggregator`; resolves after timeout or when all known nodes have responded | `protocol.py:463` |
-| `handle_intercom(message)` | `INTERCOM` | Decrypts hybrid-encrypted payload and injects into internal bus | `protocol.py:491` |
-
----
-
 ## `HiveMapper` (`hivemind_bus_client/hive_map.py:38`)
 
 Collects responsive PINGs from a flood and builds a directed hive topology graph.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,12 @@ client.emit(Message("recognizer_loop:utterance", {"utterances": ["hello world"]}
 
 ## Documentation Guides
 
+- [Setup walkthrough](setup.md) - Pair a satellite with a hub step by step.
 - [Installation](installation.md) - Getting started.
 - [API Reference](api.md) - `HiveMessage`, `HiveMessageType`, `HiveMessageBusClient`, `BinaryDataCallbacks`, `NodeIdentity`.
 - [Client API](client_api.md) - `HiveMessageBusClient` and `HiveMindHTTPClient` usage.
-- [Async client](async_client.md) - `AsyncHiveMessageBusClient` for asyncio-native applications (FastAPI, aiohttp, async chat bots). Optional: `pip install hivemind-bus-client[async]`.
-- [Fakes](fakebus.md) - `AsyncFakeHiveMessageBus`, the in-process stand-in for `AsyncHiveMessageBusClient` used by tests and embedded scenarios.
+- [Async Client](async_client.md) - `AsyncHiveMessageBusClient` for asyncio-native applications.
+- [Fakes](fakebus.md) - `AsyncFakeHiveMessageBus` in-process stand-in for testing.
 - [Message Types](message_types.md) - `HiveMessage`, `HiveMessageType` enum, routing, serialization.
 - [Binary Serialization](serialization.md) - Bitstring wire format, `get_bitstring`, `decode_bitstring` (reference implementation).
 - [Binary Handlers](binary_handlers.md) - `BinaryDataCallbacks` for TTS audio and file transfers.

--- a/docs/message_types.md
+++ b/docs/message_types.md
@@ -30,7 +30,7 @@ The `msg_type` (defined in `hivemind_bus_client.message.HiveMessageType`) dictat
 
 QUERY propagates upstream like ESCALATE, but stops as soon as one node can respond.
 
-**Satellite behaviour** (`HiveMindSlaveProtocol.handle_query` — `protocol.py:446`):
+**Satellite behaviour** (`HiveMindSlaveProtocol.handle_query` — `protocol.py:311`):
 - Inner payload must be `BUS` or `INTERCOM`.
 - `BUS` payloads are dispatched to `handle_bus`.
 - `INTERCOM` payloads are dispatched to `handle_intercom`.
@@ -61,7 +61,7 @@ def on_speak(msg):
 
 CASCADE propagates like PROPAGATE (bidirectional flood) but expects responses from all reachable nodes. Responses are optional — nodes that cannot answer simply stay silent.
 
-**Satellite behaviour** (`HiveMindSlaveProtocol.handle_cascade` — `protocol.py:463`):
+**Satellite behaviour** (`HiveMindSlaveProtocol.handle_cascade` — `protocol.py:436`):
 
 Responses are buffered in a `CascadeAggregator` (`protocol.py:21`). After `cascade_timeout` seconds (default 5.0) **or** when the number of responses reaches the known node count from `hive_mapper`, the `cascade_select_callback` picks the best response and emits it on the internal bus.
 
@@ -102,10 +102,6 @@ from hivemind_bus_client.decorators import on_cascade
 def on_skills(msg):
     print(msg.data["skills"])
 ```
-
-**Satellite behaviour** (`HiveMindSlaveProtocol.handle_ping` — `protocol.py:404`):
-
-`handle_propagate` passes the inner PING `HiveMessage` (`message.payload`) to `handle_ping` (`protocol.py:395`). `handle_ping` expects `msg_type == PING` and reads `message.payload` directly as the ping dict. If the `flood_id` has not been seen before, the node builds and emits its own responsive PING (same `flood_id`) wrapped in a new PROPAGATE.
 
 ## PING Flood — Network Discovery
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,180 @@
+# Setup walkthrough: pairing a satellite with a hub
+
+This guide walks through installing the library, registering a satellite on a hub, and verifying the connection.
+
+## Prerequisites
+
+- A running [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub (the machine that hosts the OVOS skill engine)
+- Python 3.9+ on the satellite machine
+- Network access from the satellite to the hub on port 5678 (WebSocket) or 5679 (HTTP)
+
+## 1. Install the library
+
+```bash
+pip install hivemind_bus_client
+```
+
+## 2. Register this satellite on the hub
+
+On the **hub machine**, create an access key for this satellite:
+
+```bash
+hivemind-core add-client --name "living-room-satellite"
+```
+
+Output:
+
+```
+Added satellite: living-room-satellite
+  access-key : 42caf3d2405075fb9e7a4e1ff44e4c4f
+  password   : 5ae486f7f1c26bd4645bd052e4af3ea3
+```
+
+Keep the access key and password — you need them on the satellite.
+
+To give the satellite admin rights (able to send BROADCAST messages):
+
+```bash
+hivemind-core make-admin --name "living-room-satellite"
+```
+
+## 3. Save credentials on the satellite
+
+On the **satellite machine**:
+
+```bash
+hivemind-client set-identity \
+  --key      "42caf3d2405075fb9e7a4e1ff44e4c4f" \
+  --password "5ae486f7f1c26bd4645bd052e4af3ea3" \
+  --host     ws://192.168.1.10 \
+  --port     5678 \
+  --siteid   living-room
+```
+
+Credentials are written to `~/.config/hivemind/_identity.json`. The `--siteid` value is injected into every outgoing OVOS message context so the hub can route responses back to the right room.
+
+For an encrypted (TLS) connection use `wss://` instead of `ws://`. The library accepts self-signed certificates by default (`self_signed=True`).
+
+## 4. Verify connectivity
+
+```bash
+hivemind-client ping --host ws://192.168.1.10 --port 5678
+```
+
+A successful response looks like:
+
+```
+Pong from hub (192.168.1.10:5678) — RTT 12 ms
+```
+
+## 5. Open an interactive terminal
+
+```bash
+hivemind-client terminal
+```
+
+Type a sentence and press Enter. The hub processes it and the spoken response is printed:
+
+```
+== connected to HiveMind
+Utterance: what time is it
+> It is 3:45 PM.
+```
+
+Press Ctrl-C to disconnect.
+
+## 6. Use the library in code
+
+```python
+from hivemind_bus_client import HiveMessageBusClient
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+# Loads credentials from ~/.config/hivemind/_identity.json
+client = HiveMessageBusClient()
+client.connect()
+
+client.on_mycroft("speak", lambda msg: print("Hub says:", msg.data["utterance"]))
+
+client.emit(HiveMessage(
+    HiveMessageType.BUS,
+    Message("recognizer_loop:utterance", {"utterances": ["hello world"]}),
+))
+
+input("Press Enter to disconnect...\n")
+client.close()
+```
+
+Or pass credentials directly without saving them:
+
+```python
+client = HiveMessageBusClient(
+    key="42caf3d2405075fb9e7a4e1ff44e4c4f",
+    password="5ae486f7f1c26bd4645bd052e4af3ea3",
+    host="ws://192.168.1.10",
+    port=5678,
+)
+client.connect()
+```
+
+## SSL / TLS
+
+For production deployments where the hub uses a signed certificate:
+
+```python
+client = HiveMessageBusClient(
+    host="wss://hub.example.com",
+    port=5678,
+    self_signed=False,   # enforce certificate verification
+)
+```
+
+For self-hosted hubs with a self-signed certificate keep `self_signed=True` (the default).
+
+## Troubleshooting
+
+### Connection refused or timeout
+
+- Confirm the hub is running: `systemctl status hivemind-core`
+- Check the firewall allows port 5678: `sudo ufw allow 5678/tcp`
+- Use `ws://` (not `http://`) for the host URL
+
+### Handshake timeout
+
+```
+RuntimeError: timed out waiting for handshake
+```
+
+The TCP connection opened but the hub rejected or did not complete the handshake. Common causes:
+
+- Wrong access key or password — re-run `hivemind-core add-client` and update `set-identity`
+- The satellite's IP is blocked — check `hivemind-core blacklist-client`
+- Firewall is stateful and drops the upgrade: ensure WebSocket upgrades are not filtered
+
+### Decryption error
+
+```
+got encrypted message, but could not decrypt!
+```
+
+The `password` does not match what the hub stored for this access key. The password is used to derive the AES session key during the handshake — a mismatch means every message is unreadable.
+
+### Multiple satellites on the same machine
+
+Each satellite needs its own `NodeIdentity`. Pass a custom identity file path:
+
+```python
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client import HiveMessageBusClient
+
+identity = NodeIdentity(identity_file="/etc/hivemind/kitchen-satellite.json")
+identity.access_key     = "..."
+identity.password       = "..."
+identity.default_master = "ws://192.168.1.10"
+identity.default_port   = 5678
+identity.site_id        = "kitchen"
+identity.save()
+
+client = HiveMessageBusClient(identity=identity)
+client.connect()
+```


### PR DESCRIPTION
Rewrites the README to zero-to-hero (the foundation client library satellites build on): satellite spectrum, hub-pairing quickstart, full library guide (connect/send/receive, ESCALATE/QUERY/BROADCAST/INTERCOM, async + binary), message-type + API reference, security, troubleshooting; adds docs/setup.md. Docs only — code/test contamination + a stray TODO.md from the drafting branch were dropped.