### PR TITLE
fix(deps): require ovos-bus-client>=2.0.0a3 (drops bundled hivemind protocol)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "poorman-handshake>=1.0.0,<2.0.0",
-    "ovos_bus_client>=1.0.0,<2.0.0",
+    "ovos_bus_client>=2.0.0a3",
     "ovos_utils>=0.3.0",
     "bitstring>=4.1.1",
     "cryptography>=41.0.1",


### PR DESCRIPTION
Published ovos-bus-client **1.5.0** (latest stable) still ships `ovos_bus_client/hpm.py:OVOSProtocol` and registers it under the `hivemind-ovos-agent-plugin` entry-point — colliding with the standalone plugin. ovos-bus-client#207 removed it (breaking → 2.x), but 2.x is alpha-only, so unpinned/`<2.0.0` installs pull the bundled 1.5.0. Pin `>=2.0.0a3` (first clean release). 2.x's breaking change is exactly that removal, which hivemind doesn't consume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraint to enable compatibility with newer releases of the bus client library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->