### PR TITLE
fix: keep hivemind-core git ref out of package metadata (unblock PyPI publish)

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,5 +13,5 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       # test deps (hivescope, the v3-capable hivemind-core, ...) come from
       # the test extra in pyproject.toml — the single source of truth
-      install_extras: 'test'
+      install_extras: 'test,e2e'
       test_path: 'tests/'

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -14,4 +14,7 @@ jobs:
       # test deps (hivescope, the v3-capable hivemind-core, ...) come from
       # the test extra in pyproject.toml — the single source of truth
       install_extras: 'test,e2e'
+      # the v3 e2e matrix needs a Noise-capable hivemind-core; installed here
+      # as a git ref (kept out of pyproject so the wheel stays PyPI-publishable)
+      pre_install_pip: 'hivemind-core @ git+https://github.com/JarbasHiveMind/HiveMind-core@feat/protocol-v3-noise'
       test_path: 'tests/'

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      # test deps (hivescope, the v3-capable hivemind-core, ...) come from
+      # the test extra in pyproject.toml — the single source of truth
       install_extras: 'test'
-      # hivescope is required by tests/e2e/
-      pre_install_pip: '"hivescope==0.3.0a1"'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,5 @@ jobs:
       # needs the unit suite. Test deps come from the test extra in
       # pyproject.toml — the single source of truth, nothing pinned here.
       install_extras: 'test'
-      pre_install_pip: 'pytest-asyncio "poorman-handshake>=2.0.0a1"'
       test_path: 'tests/ --ignore=tests/e2e'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,5 +15,6 @@ jobs:
       # e2e is exercised (with hivescope) by build-tests.yml; coverage only
       # needs the unit suite. Test deps come from the test extra in
       # pyproject.toml — the single source of truth, nothing pinned here.
+      install_extras: 'test'
       test_path: 'tests/ --ignore=tests/e2e'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,6 @@ jobs:
       # e2e is exercised (with hivescope) by build-tests.yml; coverage only
       # needs the unit suite. Test deps come from the test extra in
       # pyproject.toml — the single source of truth, nothing pinned here.
-      install_extras: 'test'
+      pre_install_pip: 'pytest-asyncio'
       test_path: 'tests/ --ignore=tests/e2e'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,8 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'hivemind_bus_client'
-      test_path: 'tests/'
-      pre_install_pip: '"hivescope==0.3.0a1" pytest-asyncio'
+      # e2e is exercised (with hivescope) by build-tests.yml; coverage only
+      # needs the unit suite. Test deps come from the test extra in
+      # pyproject.toml — the single source of truth, nothing pinned here.
+      test_path: 'tests/ --ignore=tests/e2e'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,5 +16,6 @@ jobs:
       # needs the unit suite. Test deps come from the test extra in
       # pyproject.toml — the single source of truth, nothing pinned here.
       install_extras: 'test'
+      pre_install_pip: 'pytest-asyncio "poorman-handshake>=2.0.0a1"'
       test_path: 'tests/ --ignore=tests/e2e'
       min_coverage: 0

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -21,6 +21,7 @@ from hivemind_bus_client.serialization import get_bitstring, decode_bitstring
 from hivemind_bus_client.util import serialize_message
 from hivemind_bus_client.encryption import (encrypt_as_json, decrypt_from_json, encrypt_bin, decrypt_bin,
                                             SupportedEncodings, SupportedCiphers, hybrid_encrypt)
+from hivemind_bus_client.noise import NoiseTransportFailed
 from poorman_handshake.asymmetric.utils import load_RSA_key, sign_RSA
 
 
@@ -106,8 +107,16 @@ class HiveMessageBusClient(OVOSBusClient):
                  internal_bus: Optional[OVOSBusClient] = None,
                  bin_callbacks: BinaryDataCallbacks = BinaryDataCallbacks(),
                  websocket_ping_interval: Optional[float] = None,
-                 websocket_ping_timeout: Optional[float] = None):
+                 websocket_ping_timeout: Optional[float] = None,
+                 max_protocol_version: int = 3):
         self.bin_callbacks = bin_callbacks
+        # highest HiveMind protocol version this client will negotiate
+        # (HIVEMIND-WIRE-1 §2). 3 -> Noise handshake when the server also
+        # supports it; servers capped at 2 or lower fall back to the legacy
+        # handshake transparently. Set to 2 to force the legacy handshake.
+        self.max_protocol_version = max_protocol_version
+        # established protocol v3 Noise session (None on v2 and below)
+        self.noise_transport = None
         self.json_encoding = SupportedEncodings.JSON_HEX  # server defaults before it was made configurable
         self.cipher = SupportedCiphers.AES_GCM  # server defaults before it was made configurable
 
@@ -195,7 +204,8 @@ class HiveMessageBusClient(OVOSBusClient):
     def key(self, val):
         self.identity.access_key = val
 
-    def connect(self, bus=FakeBus(), protocol=None, site_id=None):
+    def connect(self, bus=FakeBus(), protocol=None, site_id=None,
+                handshake_max_retries=None):
         from hivemind_bus_client.protocol import HiveMindSlaveProtocol
 
         self.identity.site_id = site_id or self.identity.site_id
@@ -213,9 +223,15 @@ class HiveMessageBusClient(OVOSBusClient):
                 self.protocol.site_id = self.identity.site_id
 
         LOG.info("Connecting to Hivemind")
-        self.run_in_thread()
+        # bind BEFORE opening the websocket so the server's initial cleartext
+        # HELLO + HANDSHAKE parameter payloads are never missed — protocol v3
+        # needs them for Noise prologue binding (HIVEMIND-CRYPTO-1 §3.4.3)
         self.protocol.bind(bus)
-        self.wait_for_handshake()
+        self.run_in_thread()
+        # None retries forever (legacy behaviour); pass a bound so a failed
+        # handshake (e.g. wrong password on protocol v3) fails fast instead
+        # of blocking connect() indefinitely
+        self.wait_for_handshake(max_retries=handshake_max_retries)
 
     def on_open(self, *args):
         """
@@ -232,12 +248,14 @@ class HiveMessageBusClient(OVOSBusClient):
         self.connected_event.clear()
         self.handshake_event.clear()
         self.crypto_key = None
+        self.noise_transport = None
         super().on_error(*args)
 
     def on_close(self, *args):
         self.connected_event.clear()
         self.handshake_event.clear()
         self.crypto_key = None
+        self.noise_transport = None
         super().on_close(*args)
 
     def wait_for_handshake(self, timeout=5, max_retries=None):
@@ -305,7 +323,23 @@ class HiveMessageBusClient(OVOSBusClient):
             message = args[0]
         else:
             message = args[1]
-        if self.crypto_key:
+        if self.noise_transport is not None:
+            # protocol v3: every post-handshake message is a Noise transport
+            # message; there is no cleartext v3 session (CRYPTO-1 §3.4.5)
+            if not isinstance(message, bytes):
+                LOG.error("dropping non-Noise message received on a "
+                          "protocol v3 session")
+                return
+            try:
+                message = self.noise_transport.decrypt_frame(message)
+            except NoiseTransportFailed:
+                # tampered / replayed / out-of-order — MUST reject; the
+                # receive counter is now out of sync so the session is dead
+                LOG.exception("rejecting invalid Noise transport message, "
+                              "closing connection")
+                self.close()
+                return
+        elif self.crypto_key:
             # handle binary encryption
             if isinstance(message, bytes):
                 message = decrypt_bin(self.crypto_key, message, cipher=self.cipher)
@@ -428,13 +462,22 @@ class HiveMessageBusClient(OVOSBusClient):
                                        compressed=self.compress,
                                        binary_type=binary_type,
                                        hivemeta=message.metadata)
-                if self.crypto_key:
+                if self.noise_transport is not None:
+                    # protocol v3: Noise transport CipherState (replay
+                    # resistant sequential nonces) replaces the v2 AEAD
+                    ws_payload = self.noise_transport.encrypt_frame(bitstr.bytes)
+                elif self.crypto_key:
                     ws_payload = encrypt_bin(self.crypto_key, bitstr.bytes, cipher=self.cipher)
                 else:
                     ws_payload = bitstr.bytes
                 self.client.send(ws_payload, ABNF.OPCODE_BINARY)
             else:
                 ws_payload = serialize_message(message)
+                if self.noise_transport is not None:
+                    # v3 sessions are always encrypted, HELLO included
+                    ws_payload = self.noise_transport.encrypt_frame(ws_payload)
+                    self.client.send(ws_payload, ABNF.OPCODE_BINARY)
+                    return
                 if self.crypto_key:
                     ws_payload = encrypt_as_json(self.crypto_key, ws_payload,
                                                  cipher=self.cipher, encoding=self.json_encoding)

--- a/hivemind_bus_client/identity.py
+++ b/hivemind_bus_client/identity.py
@@ -151,6 +151,53 @@ class NodeIdentity:
         self.IDENTITY_FILE["default_port"] = val
 
     @property
+    def noise_key(self) -> str:
+        """
+        Get or set the path to the static X25519 private key used by the
+        protocol-v3 Noise handshake (HIVEMIND-CRYPTO-1 §2/§3.4).
+
+        The key is generated and persisted on first use; it must survive
+        restarts so key pinning survives reconnection.
+
+        Returns:
+            str: The path to the Noise static key file.
+        """
+        return self.IDENTITY_FILE.get("noise_key") or \
+            f"{dirname(self.IDENTITY_FILE.path)}/{self.name}_noise.key"
+
+    @noise_key.setter
+    def noise_key(self, val: str):
+        """Set the path to the Noise static X25519 private key file."""
+        self.IDENTITY_FILE["noise_key"] = val
+
+    @property
+    def pinned_noise_keys(self) -> Dict[str, str]:
+        """TOFU-pinned Noise static public keys, node_id → hex pubkey.
+
+        On the first completed XXpsk2 handshake with a peer the learned
+        static key is pinned against the peer's node id; on every later
+        handshake a mismatch is a fatal authentication failure
+        (HIVEMIND-CRYPTO-1 §3.4.5).
+        """
+        return self.IDENTITY_FILE.get("pinned_noise_keys") or {}
+
+    def get_pinned_noise_key(self, node_id: str) -> Optional[str]:
+        """Return the pinned Noise static public key for a node id, if any."""
+        return self.pinned_noise_keys.get(node_id)
+
+    def pin_noise_key(self, node_id: str, pubkey: str) -> None:
+        """Pin (or re-assert) a peer's Noise static public key.
+
+        Args:
+            node_id: The peer's node identifier.
+            pubkey: Hex-encoded X25519 static public key.
+        """
+        keys = self.pinned_noise_keys
+        keys[node_id] = pubkey
+        self.IDENTITY_FILE["pinned_noise_keys"] = keys
+        self.save()
+
+    @property
     def trusted_keys(self) -> Dict[str, str]:
         """Get the trusted keys mapping (alias → public key).
 

--- a/hivemind_bus_client/noise.py
+++ b/hivemind_bus_client/noise.py
@@ -1,0 +1,226 @@
+"""HiveMind protocol version 3 — Noise handshake and transport glue.
+
+Implements the version-3 session layer of HIVEMIND-CRYPTO-1 §3.4 on top of
+the ``poorman_handshake.noise`` primitive:
+
+- **negotiation helpers** — the server advertises supported Noise ``patterns``
+  and ``suites`` (preference ordered); the node selects one of each and fixes
+  the Noise protocol name (HIVEMIND-CRYPTO-1 §3.4.1/§3.4.2)
+- **prologue construction** — the cleartext ``HELLO`` payload, the cleartext
+  parameter ``HANDSHAKE`` payload, and the node's selected protocol name are
+  bound into the Noise prologue so any tampering with the negotiation aborts
+  the handshake (HIVEMIND-CRYPTO-1 §3.4.3)
+- **transport framing** — after ``Split()`` every message travels as a Noise
+  transport message under the per-direction ``CipherState``s, whose strictly
+  sequential nonce counters give replay resistance and ordering enforcement
+  (HIVEMIND-CRYPTO-1 §3.4.5); the fresh-IV AEAD construction of protocol
+  versions 0-2 is not used on a version-3 session
+
+Protocol version 2 and below are untouched: this module is only entered when
+both peers negotiate version 3.
+"""
+import json
+import os
+import threading
+from binascii import hexlify
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+try:
+    from poorman_handshake.noise import NoiseHandShake, derive_psk
+
+    NOISE_SUPPORTED = True
+except ImportError:  # poorman-handshake without the noise primitive
+    NoiseHandShake = None  # type: ignore
+    derive_psk = None  # type: ignore
+    NOISE_SUPPORTED = False
+
+# HiveMind protocol version that switches the handshake to Noise
+PROTOCOL_V3 = 3
+
+# registered handshake patterns, preference ordered (HIVEMIND-CRYPTO-1 §3.4.2)
+NOISE_PATTERN_XX = "XXpsk2"  # general case, MUST support
+NOISE_PATTERN_KK = "KKpsk0"  # pre-provisioned static keys, MAY support
+NOISE_PATTERNS: List[str] = [NOISE_PATTERN_KK, NOISE_PATTERN_XX]
+
+# registered cipher suites, preference ordered (HIVEMIND-CRYPTO-1 §3.4.1)
+NOISE_SUITE_CHACHA = "25519_ChaChaPoly_SHA256"  # MUST support
+NOISE_SUITES: List[str] = [NOISE_SUITE_CHACHA]
+
+# transport frame markers: the first plaintext byte tags the inner framing so
+# the receiver knows how to parse the decrypted bytes
+_FRAME_JSON = b"\x00"  # utf-8 JSON HiveMessage
+_FRAME_BINARY = b"\x01"  # HIVEMIND-WIRE-1 binary frame (bitstring)
+
+
+class NoiseHandshakeFailed(Exception):
+    """The Noise handshake aborted — wrong password/PSK, tampered
+    negotiation (prologue mismatch), static-key contradiction, or a
+    malformed handshake message. Fatal: the connection must be rejected."""
+
+
+class NoiseTransportFailed(Exception):
+    """A Noise transport message failed to decrypt at the current receive
+    counter — tampering, replay, or reordering. Fatal for the session."""
+
+
+def canonical_json(payload: Dict[str, Any]) -> bytes:
+    """Serialize a payload dict deterministically for prologue binding.
+
+    Both peers must derive identical prologue bytes from the negotiation
+    payloads; sorted keys + compact separators make the serialization
+    independent of dict ordering and formatting.
+    """
+    return json.dumps(payload, sort_keys=True,
+                      separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def noise_protocol_name(pattern: str, suite: str) -> str:
+    """Full Noise protocol name for a pattern + suite selection."""
+    return f"Noise_{pattern}_{suite}"
+
+
+def select_noise_options(server_patterns: List[str],
+                         server_suites: List[str],
+                         pinned_remote_key: Optional[str] = None
+                         ) -> Optional[Tuple[str, str]]:
+    """Pick the handshake pattern and suite from the server's advertised lists.
+
+    ``KKpsk0`` is preferred when the remote static key is pre-provisioned
+    (pinned) and the server offers it; otherwise ``XXpsk2``. Returns
+    ``(pattern, suite)`` or None when there is no mutual option.
+    """
+    suite = next((s for s in server_suites if s in NOISE_SUITES), None)
+    if suite is None:
+        return None
+    if pinned_remote_key and NOISE_PATTERN_KK in server_patterns:
+        return NOISE_PATTERN_KK, suite
+    if NOISE_PATTERN_XX in server_patterns:
+        return NOISE_PATTERN_XX, suite
+    return None
+
+
+def build_prologue(hello_payload: Dict[str, Any],
+                   handshake_payload: Dict[str, Any],
+                   protocol_name: str) -> bytes:
+    """Prologue bytes per HIVEMIND-CRYPTO-1 §3.4.3.
+
+    Binds, in order: the server's cleartext ``HELLO`` payload, its cleartext
+    parameter ``HANDSHAKE`` payload (advertised versions, patterns, suites,
+    encodings, every other parameter), and the node's selected Noise protocol
+    name. Both peers must supply identical bytes or the handshake aborts —
+    this is the downgrade/tampering protection.
+    """
+    return (canonical_json(hello_payload)
+            + canonical_json(handshake_payload)
+            + protocol_name.encode("utf-8"))
+
+
+class NoiseTransport:
+    """A completed protocol-v3 Noise session.
+
+    Wraps the post-``Split()`` transport of a :class:`NoiseHandShake` with
+    thread-safe per-direction locks (the CipherState nonce counters are
+    strictly sequential — encryption order must match send order) and the
+    HiveMind frame markers that distinguish JSON from binary frames after
+    decryption.
+    """
+
+    def __init__(self, handshake: "NoiseHandShake"):
+        if not handshake.handshake_finished:
+            raise NoiseHandshakeFailed("handshake not finished")
+        self._hs = handshake
+        self._send_lock = threading.Lock()
+        self._recv_lock = threading.Lock()
+        self.remote_static_key: Optional[str] = (
+            hexlify(handshake.remote_pubkey).decode("utf-8")
+            if handshake.remote_pubkey else None)
+        self.handshake_hash: Optional[bytes] = handshake.handshake_hash
+
+    def encrypt_frame(self, payload: Union[str, bytes]) -> bytes:
+        """Encrypt one outgoing message as a Noise transport message.
+
+        Args:
+            payload: a serialized JSON HiveMessage (str) or a WIRE-1 binary
+                frame (bytes).
+
+        Returns:
+            Ciphertext bytes to send as a single (binary) websocket message.
+        """
+        if isinstance(payload, str):
+            plaintext = _FRAME_JSON + payload.encode("utf-8")
+        else:
+            plaintext = _FRAME_BINARY + bytes(payload)
+        with self._send_lock:
+            return self._hs.encrypt(plaintext)
+
+    def decrypt_frame(self, data: bytes) -> Union[str, bytes]:
+        """Decrypt one incoming Noise transport message.
+
+        Raises:
+            NoiseTransportFailed: on any AEAD failure — tampering, replay, or
+                out-of-order delivery. Per HIVEMIND-CRYPTO-1 §3.4.5 the
+                message MUST be rejected and never retried under another
+                nonce; callers should treat this as fatal for the session.
+        """
+        with self._recv_lock:
+            try:
+                plaintext = self._hs.decrypt(bytes(data))
+            except Exception as e:
+                raise NoiseTransportFailed(
+                    f"Noise transport message rejected (tampered, replayed "
+                    f"or out-of-order): {e}") from e
+        marker, body = plaintext[:1], plaintext[1:]
+        if marker == _FRAME_JSON:
+            return body.decode("utf-8")
+        if marker == _FRAME_BINARY:
+            return body
+        raise NoiseTransportFailed(f"unknown v3 frame marker: {marker!r}")
+
+
+def start_noise_handshake(initiator: bool,
+                          pattern: str,
+                          suite: str,
+                          password: Union[str, bytes],
+                          node_id: str,
+                          prologue: bytes,
+                          key_path: Optional[str] = None,
+                          remote_pubkey: Optional[str] = None
+                          ) -> "NoiseHandShake":
+    """Initialize a Noise handshake for a HiveMind protocol-v3 connection.
+
+    The PSK is derived from the shared site password with argon2id, salted
+    by ``SHA-256(node_id)`` of the *server's* node id (HIVEMIND-CRYPTO-1
+    §3.4.4). The static X25519 key is loaded from (or generated and
+    persisted to) ``key_path``.
+
+    Args:
+        initiator: True on the node (client) side, False on the server side.
+        pattern: selected handshake pattern (``XXpsk2`` or ``KKpsk0``).
+        suite: selected cipher suite (e.g. ``25519_ChaChaPoly_SHA256``).
+        password: the shared site password (the only secret; never
+            transmitted — it authenticates the handshake as the Noise PSK).
+        node_id: the server's node id announced in its cleartext HELLO.
+        prologue: bytes from :func:`build_prologue`.
+        key_path: where the static X25519 private key persists.
+        remote_pubkey: hex-encoded pinned remote static key (required for
+            ``KKpsk0``).
+    """
+    if not NOISE_SUPPORTED:
+        raise NoiseHandshakeFailed(
+            "poorman-handshake was installed without the noise primitive")
+    name = noise_protocol_name(pattern, suite)
+    if key_path and os.path.dirname(key_path):
+        os.makedirs(os.path.dirname(key_path), exist_ok=True)
+    try:
+        return NoiseHandShake(
+            initiator=initiator,
+            path=key_path,
+            password=password,
+            node_id=node_id,
+            remote_pubkey=remote_pubkey if pattern == NOISE_PATTERN_KK else None,
+            prologue=prologue,
+            pattern=name.encode("utf-8"),
+        )
+    except Exception as e:
+        raise NoiseHandshakeFailed(f"failed to initialize {name}: {e}") from e

--- a/hivemind_bus_client/noise.py
+++ b/hivemind_bus_client/noise.py
@@ -45,7 +45,8 @@ NOISE_PATTERNS: List[str] = [NOISE_PATTERN_KK, NOISE_PATTERN_XX]
 
 # registered cipher suites, preference ordered (HIVEMIND-CRYPTO-1 §3.4.1)
 NOISE_SUITE_CHACHA = "25519_ChaChaPoly_SHA256"  # MUST support
-NOISE_SUITES: List[str] = [NOISE_SUITE_CHACHA]
+NOISE_SUITE_AESGCM = "25519_AESGCM_SHA256"  # MAY support (Web Crypto peers)
+NOISE_SUITES: List[str] = [NOISE_SUITE_CHACHA, NOISE_SUITE_AESGCM]
 
 # transport frame markers: the first plaintext byte tags the inner framing so
 # the receiver knows how to parse the decrypted bytes
@@ -90,7 +91,9 @@ def select_noise_options(server_patterns: List[str],
     (pinned) and the server offers it; otherwise ``XXpsk2``. Returns
     ``(pattern, suite)`` or None when there is no mutual option.
     """
-    suite = next((s for s in server_suites if s in NOISE_SUITES), None)
+    # walk our own preference-ordered list so 25519_ChaChaPoly_SHA256 wins
+    # whenever both peers support it, regardless of the server's list order
+    suite = next((s for s in NOISE_SUITES if s in server_suites), None)
     if suite is None:
         return None
     if pinned_remote_key and NOISE_PATTERN_KK in server_patterns:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -1,3 +1,4 @@
+import json
 import random
 
 import threading
@@ -16,6 +17,11 @@ from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers,
 from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.noise import (NOISE_SUPPORTED, PROTOCOL_V3,
+                                       NoiseTransport, NoiseHandshakeFailed,
+                                       build_prologue, canonical_json,
+                                       noise_protocol_name, select_noise_options,
+                                       start_noise_handshake)
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import load_RSA_key
 
@@ -185,6 +191,11 @@ class HiveMindSlaveProtocol:
     cascade_select_callback: Optional[Callable[[List[HiveMessage]], Optional[HiveMessage]]] = None
     hive_mapper: Optional[HiveMapper] = None
     cascade_aggregator: Optional[CascadeAggregator] = field(default=None, repr=False)
+    # protocol v3 (Noise handshake) state — HIVEMIND-CRYPTO-1 §3.4
+    noise_handshake: Optional[object] = field(default=None, repr=False)
+    _noise_pattern: Optional[str] = field(default=None, repr=False)
+    _server_hello_payload: Optional[dict] = field(default=None, repr=False)
+    _server_handshake_payload: Optional[dict] = field(default=None, repr=False)
 
     def bind(self, bus: Optional[MessageBusClient] = None):
         if self.identity is None:
@@ -233,9 +244,172 @@ class HiveMindSlaveProtocol:
             self.mpubkey = message.payload.get("pubkey")
             node_id = message.payload.get("node_id", "")
             self.internal_protocol.node_id = node_id
+            # retained for the Noise prologue (HIVEMIND-CRYPTO-1 §3.4.3)
+            self._server_hello_payload = dict(message.payload)
             LOG.info(f"Connected to HiveMind: {node_id}")
 
+    # ------------------------------------------------------- protocol v3 (Noise)
+    @property
+    def _noise_pin_id(self) -> str:
+        """Identifier the server's Noise static key is pinned against.
+
+        Uses the connection endpoint (host:port) so that distinct servers
+        that announce the same default node_id do not collide in the pin
+        store.
+        """
+        cfg = getattr(self.hm, "config", None)
+        if cfg is not None:
+            return f"{cfg.host}:{cfg.port}"
+        return self.internal_protocol.node_id or "unknown"
+
+    def _should_use_noise(self, payload: dict) -> bool:
+        """True when both peers are v3-capable and can run the Noise handshake.
+
+        Per HIVEMIND-WIRE-1 §2 both peers operate at the highest version both
+        support: the server advertises ``max_protocol_version`` >= 3 together
+        with its Noise ``patterns``/``suites``, and this client must support
+        protocol v3 (noise primitive available + shared password set). Any
+        other combination falls back to the legacy (v2 and below) handshake.
+        """
+        if not NOISE_SUPPORTED or not self.identity or not self.identity.password:
+            return False
+        if getattr(self.hm, "max_protocol_version", 2) < PROTOCOL_V3:
+            return False
+        if payload.get("max_protocol_version", 1) < PROTOCOL_V3:
+            return False
+        noise_params = payload.get("noise")
+        if not isinstance(noise_params, dict):
+            return False
+        pinned = self.identity.get_pinned_noise_key(self._noise_pin_id)
+        return select_noise_options(noise_params.get("patterns") or [],
+                                    noise_params.get("suites") or [],
+                                    pinned) is not None
+
+    def start_noise_handshake(self, server_payload: dict):
+        """Send Noise handshake message 1 (HIVEMIND-CRYPTO-1 §3.4.3 step 3).
+
+        Selects one pattern and one suite from the server's advertised lists,
+        binds the negotiation into the prologue, and carries the Noise message
+        bytes inside the regular HANDSHAKE envelope. The Noise payload carries
+        this node's preference-ordered encodings and binarize capability.
+        """
+        node_id = self.internal_protocol.node_id
+        noise_params = server_payload.get("noise") or {}
+        pinned = self.identity.get_pinned_noise_key(self._noise_pin_id)
+        selection = select_noise_options(noise_params.get("patterns") or [],
+                                         noise_params.get("suites") or [],
+                                         pinned)
+        if selection is None:
+            LOG.warning("no mutual Noise pattern/suite, falling back to legacy handshake")
+            self._legacy_start_handshake(server_payload)
+            return
+        pattern, suite = selection
+        name = noise_protocol_name(pattern, suite)
+        prologue = build_prologue(self._server_hello_payload or {},
+                                  server_payload, name)
+        LOG.info(f"starting protocol v3 handshake: {name}")
+        try:
+            self.noise_handshake = start_noise_handshake(
+                initiator=True, pattern=pattern, suite=suite,
+                password=self.identity.password, node_id=node_id,
+                prologue=prologue, key_path=self.identity.noise_key,
+                remote_pubkey=pinned)
+            self._noise_pattern = pattern
+            noise_payload = canonical_json({
+                "binarize": self.binarize,
+                "encodings": [str(e.value) for e in SupportedEncodings]})
+            msg1 = self.noise_handshake.write_message(noise_payload)
+        except NoiseHandshakeFailed:
+            LOG.exception("failed to start Noise handshake")
+            self._abort_noise("failed to initialize Noise handshake")
+            return
+        self.hm.emit(HiveMessage(HiveMessageType.HANDSHAKE, {
+            "noise": {"pattern": pattern, "suite": suite,
+                      "msg": msg1.hex()}}))
+
+    def receive_noise_handshake(self, payload: dict):
+        """Consume the server's Noise handshake message (§3.4.3 step 4).
+
+        Any authentication failure — wrong password (PSK mismatch), tampered
+        negotiation (prologue mismatch), or a static key contradicting the
+        pinned key — is fatal: the handshake aborts and the connection is
+        rejected. On success the two transport CipherStates take over all
+        session traffic and the encrypted HELLO is sent as the first Noise
+        transport message.
+        """
+        try:
+            msg = bytes.fromhex(payload["noise"]["msg"])
+        except (KeyError, TypeError, ValueError):
+            self._abort_noise("malformed Noise handshake envelope")
+            return
+        try:
+            noise_payload = self.noise_handshake.read_message(msg)
+            if not self.noise_handshake.handshake_finished:
+                # XXpsk2 message 3: our (encrypted) static key + final DH mix
+                msg3 = self.noise_handshake.write_message(b"")
+                self.hm.emit(HiveMessage(HiveMessageType.HANDSHAKE,
+                                         {"noise": {"msg": msg3.hex()}}))
+            transport = NoiseTransport(self.noise_handshake)
+        except Exception:
+            # wrong password / tampered prologue / bad static key -> fatal,
+            # fails cryptographically at handshake time (§3.4.3)
+            LOG.exception("protocol v3 Noise handshake FAILED "
+                          "(wrong password or tampered negotiation)")
+            self._abort_noise("Noise handshake authentication failure")
+            return
+
+        # TOFU-then-pin the server's static key (§3.4.5)
+        pin_id = self._noise_pin_id
+        pinned = self.identity.get_pinned_noise_key(pin_id)
+        if pinned and transport.remote_static_key != pinned:
+            LOG.error(f"server Noise static key CHANGED for {pin_id} — "
+                      "possible man-in-the-middle, aborting")
+            self._abort_noise("pinned key mismatch")
+            return
+        if not pinned and transport.remote_static_key:
+            self.identity.pin_noise_key(pin_id, transport.remote_static_key)
+
+        try:
+            server_selection = json.loads(noise_payload.decode("utf-8")) if noise_payload else {}
+        except ValueError:
+            server_selection = {}
+        if server_selection.get("encoding"):
+            self.hm.json_encoding = server_selection["encoding"]
+
+        self.hm.noise_transport = transport  # session encryption from here on
+        self.noise_handshake = None
+        LOG.info("protocol v3 Noise session established "
+                 f"(pattern={self._noise_pattern})")
+
+        # first Noise transport message: session data + site id + pubkey
+        sess = Session(self.hm.session_id)
+        self.hm.emit(HiveMessage(HiveMessageType.HELLO,
+                                 {"pubkey": self.identity.public_key,
+                                  "session": sess.serialize(),
+                                  "site_id": self.site_id}))
+        self.hm.handshake_event.set()
+
+    def _abort_noise(self, reason: str):
+        """Fatal handshake failure — reject the connection (§3.4.3)."""
+        LOG.error(f"aborting protocol v3 connection: {reason}")
+        self.noise_handshake = None
+        self.hm.noise_transport = None
+        try:
+            self.hm.close()
+        except Exception:
+            pass
+
     def start_handshake(self):
+        # negotiated protocol v3 -> the Noise handshake replaces the legacy
+        # password/pubkey handshake
+        if self.noise_handshake is not None:
+            return  # Noise handshake already in flight, keep waiting
+        if self._server_handshake_payload and self._should_use_noise(self._server_handshake_payload):
+            self.start_noise_handshake(self._server_handshake_payload)
+            return
+        self._legacy_start_handshake(self._server_handshake_payload or {})
+
+    def _legacy_start_handshake(self, server_payload: dict):
         if self.binarize:
             LOG.info("hivemind supports binarization protocol")
         else:
@@ -279,6 +453,10 @@ class HiveMindSlaveProtocol:
     def handle_handshake(self, message: HiveMessage):
         LOG.info(f"HANDSHAKE: {message.payload}")
         assert message.msg_type == HiveMessageType.HANDSHAKE
+        # protocol v3: server's Noise handshake message
+        if "noise" in message.payload and self.noise_handshake is not None:
+            self.receive_noise_handshake(message.payload)
+            return
         # master is performing the handshake
         if "envelope" in message.payload:
             envelope = message.payload["envelope"]
@@ -306,11 +484,22 @@ class HiveMindSlaveProtocol:
                 # TODO - flag to give preference to pre-shared key over handshake
 
             self.binarize = message.payload.get("binarize", False)
+
+            # retained for the Noise prologue + handshake retries
+            self._server_handshake_payload = dict(message.payload)
+
+            # protocol v3 negotiation (HIVEMIND-WIRE-1 §2): both peers
+            # v3-capable -> Noise handshake; otherwise fall through to the
+            # legacy (v2) handshake below, unchanged
+            if self._should_use_noise(self._server_handshake_payload):
+                self.start_noise_handshake(self._server_handshake_payload)
+                return
+
             # TODO - flag to give preference to / require password or use RSA handshake
             # currently if password is set then it is always used
             if message.payload.get("password") and self.identity.password:
                 self.pswd_handshake = PasswordHandShake(self.identity.password)
-                self.start_handshake()
+                self._legacy_start_handshake(self._server_handshake_payload)
 
     def _is_source_trusted(self, message: HiveMessage) -> bool:
         """Check if the message originates from a trusted peer.

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 
 import threading
@@ -30,6 +31,21 @@ from poorman_handshake.asymmetric.utils import load_RSA_key
 # wrapping this control message (protocol contract with hivemind-core; the
 # end-of-stream is content, not metadata).
 QUERY_STREAM_END = "hive.query.complete"
+
+
+def _pw_min_bits() -> float:
+    """Minimum password entropy (bits) enforced when building the shared-password
+    handshake.
+
+    poorman-handshake refuses guessable passwords by default; deployments that
+    knowingly use a weak shared secret (or tests) can disable the runtime check
+    with the ``HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK`` env var (mirrors the
+    hivemind-core server-side backstop, without importing it).
+    """
+    disabled = os.environ.get(
+        "HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+    return 0.0 if disabled else 40.0
 
 
 class CascadeAggregator:
@@ -201,7 +217,8 @@ class HiveMindSlaveProtocol:
         if self.identity is None:
             self.identity = self.hm.identity or NodeIdentity()
         self.handshake = HandShake(self.identity.private_key)
-        self.pswd_handshake = PasswordHandShake(self.identity.password) if self.identity.password else None
+        self.pswd_handshake = (PasswordHandShake(self.identity.password, min_bits=_pw_min_bits())
+                               if self.identity.password else None)
 
         if bus is None:
             bus = MessageBusClient()
@@ -498,7 +515,8 @@ class HiveMindSlaveProtocol:
             # TODO - flag to give preference to / require password or use RSA handshake
             # currently if password is set then it is always used
             if message.payload.get("password") and self.identity.password:
-                self.pswd_handshake = PasswordHandShake(self.identity.password)
+                self.pswd_handshake = PasswordHandShake(self.identity.password,
+                                                        min_bits=_pw_min_bits())
                 self._legacy_start_handshake(self._server_handshake_payload)
 
     def _is_source_trusted(self, message: HiveMessage) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,12 @@ test = [
 ]
 e2e = [
     "hivescope>=0.5.0a2",
-    # the protocol v3 e2e matrix needs a v3-capable (Noise) hivemind-core on
-    # the master side; TODO: replace with a prerelease floor pin once the
-    # hivemind-core protocol v3 PR is released
-    "hivemind-core @ git+https://github.com/JarbasHiveMind/HiveMind-core@feat/protocol-v3-noise",
+    # the protocol v3 e2e matrix additionally needs a v3-capable (Noise)
+    # hivemind-core on the master side. It is installed by the build-tests
+    # workflow via pre_install_pip (a git ref), NOT declared here — PyPI
+    # rejects packages whose metadata carries a direct URL dependency.
+    # TODO: replace with a prerelease floor pin once hivemind-core protocol
+    # v3 is released, then add it back here.
 ]
 benchmark = [
     "websockets>=10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "websockets>=10.0",
+]
+e2e = [
     "hivescope>=0.5.0a2",
     # the protocol v3 e2e matrix needs a v3-capable (Noise) hivemind-core on
     # the master side; TODO: replace with a prerelease floor pin once the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "poorman-handshake>=1.0.0,<2.0.0",
+    # TODO: switch to a PyPI prerelease floor pin (poorman-handshake>=<alpha
+    # shipping poorman_handshake.noise>,<2.0.0) once JarbasHiveMind/poorman_handshake#17
+    # is released; git ref lets CI resolve the Noise primitive until then
+    "poorman-handshake @ git+https://github.com/JarbasHiveMind/poorman_handshake@feat/noise-handshake",
     "ovos_bus_client>=1.3.1,<3.0.0",
     "ovos_utils>=0.3.0",
     "bitstring>=4.1.1",
@@ -40,6 +43,11 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "websockets>=10.0",
+    "hivescope>=0.5.0a2",
+    # the protocol v3 e2e matrix needs a v3-capable (Noise) hivemind-core on
+    # the master side; TODO: replace with a prerelease floor pin once the
+    # hivemind-core protocol v3 PR is released
+    "hivemind-core @ git+https://github.com/JarbasHiveMind/HiveMind-core@feat/protocol-v3-noise",
 ]
 benchmark = [
     "websockets>=10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    # TODO: switch to a PyPI prerelease floor pin (poorman-handshake>=<alpha
-    # shipping poorman_handshake.noise>,<2.0.0) once JarbasHiveMind/poorman_handshake#17
-    # is released; git ref lets CI resolve the Noise primitive until then
-    "poorman-handshake @ git+https://github.com/JarbasHiveMind/poorman_handshake@feat/noise-handshake",
+    "poorman-handshake>=2.0.0a1,<3.0.0",
     "ovos_bus_client>=1.3.1,<3.0.0",
     "ovos_utils>=0.3.0",
     "bitstring>=4.1.1",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for the e2e suite.
+
+The e2e tests spin up real masters and clients in-process; both sides
+persist state under the XDG config home (node identity file, RSA .pem
+files, Noise static keys and TOFU key pins). Redirect XDG to a per-test
+temporary directory so tests never read from or write to the developer's
+real ``~/.config/hivemind`` and every test starts from a clean identity
+(no stale key pins leaking between tests).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_xdg(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    return tmp_path

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,7 +8,11 @@ real ``~/.config/hivemind`` and every test starts from a clean identity
 (no stale key pins leaking between tests).
 """
 
+import json
+
 import pytest
+
+import poorman_handshake.symmetric as _pm_symmetric
 
 
 @pytest.fixture(autouse=True)
@@ -16,4 +20,23 @@ def isolated_xdg(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    # The suite uses short human-readable passwords ("test-pwd", ...) that
+    # poorman-handshake's strength backstop would refuse. Disable the runtime
+    # check via the documented env var (honoured by the hivemind client/server
+    # handshake construction) and neutralise the library-level check for any
+    # component that builds a PasswordHandShake without threading min_bits
+    # through (e.g. the hivescope test harness).
+    monkeypatch.setenv("HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", "1")
+    monkeypatch.setattr(_pm_symmetric, "check_password_strength",
+                        lambda *args, **kwargs: None)
+
+    # Non-Noise connections top out at protocol v1, so the legacy-fallback
+    # matrix rows need the server's protocol floor below the production
+    # default (min_protocol_version=2). Only this isolated test config is
+    # lowered; the shipped default is unchanged.
+    server_cfg_dir = tmp_path / "config" / "hivemind-core"
+    server_cfg_dir.mkdir(parents=True, exist_ok=True)
+    (server_cfg_dir / "server.json").write_text(
+        json.dumps({"min_protocol_version": 0}))
     return tmp_path

--- a/tests/e2e/test_encryption.py
+++ b/tests/e2e/test_encryption.py
@@ -32,7 +32,9 @@ def test_client_and_master_agree_on_encryption():
         client = _make_client(m.network_protocol.url, "test-key", "test-password")
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
-        assert client.crypto_key is not None
+        # the session must be encrypted: v2 AES session key or the negotiated
+        # protocol v3 Noise transport (whichever version was agreed on)
+        assert client.crypto_key is not None or client.noise_transport is not None
         client.close()
     finally:
         b.stop_all()

--- a/tests/e2e/test_handshake.py
+++ b/tests/e2e/test_handshake.py
@@ -36,7 +36,8 @@ def test_client_completes_handshake_via_websocket():
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
         assert client.handshake_event.is_set()
-        assert client.crypto_key is not None
+        # encrypted session established: v2 crypto_key or v3 Noise transport
+        assert client.crypto_key is not None or client.noise_transport is not None
 
         time.sleep(1)  # let encrypted HELLO register the peer
         peers = m.connected_peers()
@@ -55,7 +56,8 @@ def test_client_crypto_key_set_after_handshake():
         client = _make_client(m.network_protocol.url, "test-key", "test-password")
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
-        assert client.crypto_key
+        # encrypted session established: v2 crypto_key or v3 Noise transport
+        assert client.crypto_key or client.noise_transport
         client.close()
     finally:
         b.stop_all()

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -63,7 +63,8 @@ def test_client_can_close_and_reconnect():
         c2 = _make_client(m.network_protocol.url, "k", "p", "reconnect")
         c2.connect(site_id="s2")
         c2.wait_for_handshake(timeout=10)
-        assert c2.crypto_key
+        # encrypted session established: v2 crypto_key or v3 Noise transport
+        assert c2.crypto_key or c2.noise_transport
         c2.close()
     finally:
         b.stop_all()

--- a/tests/e2e/test_protocol_v3_matrix.py
+++ b/tests/e2e/test_protocol_v3_matrix.py
@@ -1,0 +1,245 @@
+"""Protocol v2/v3 migration matrix (HIVEMIND-CRYPTO-1 §3.4, HIVEMIND-WIRE-1 §2).
+
+End-to-end over a real websocket, real master + real client:
+
+- v3 client ↔ v3 server: Noise session established, messages round-trip both ways
+- v3 client ↔ v2 server: negotiates down to the legacy handshake, works
+- v2 client ↔ v3 server: server accepts the legacy handshake, works
+- wrong password: the v3 handshake fails fast, no session, no fallback
+- tampered negotiation (downgrade attempt): prologue mismatch aborts the handshake
+- replayed v3 transport message: rejected, session torn down
+"""
+
+import time
+
+import pytest
+from ovos_bus_client.message import Message
+from websocket import ABNF
+
+import hivemind_core.protocol as server_protocol
+from hivemind_bus_client.client import HiveMessageBusClient
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+from hivescope import TopologyBuilder
+
+
+def _wait_for(condition, timeout: float = 10.0, interval: float = 0.05) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _make_client(url, key, password, name="v3-matrix-client",
+                 max_protocol_version=3):
+    host, port = url.replace("ws://", "").rstrip("/").split(":")
+    port = int(port)
+    identity = NodeIdentity()
+    identity.access_key = key
+    identity.password = password
+    identity.default_master = f"ws://{host}"
+    identity.default_port = port
+    identity.name = name
+    identity.site_id = f"{name}-site"
+    return HiveMessageBusClient(
+        key=key, password=password,
+        host=f"ws://{host}", port=port,
+        useragent=name, self_signed=False,
+        identity=identity,
+        max_protocol_version=max_protocol_version,
+    )
+
+
+def _master(key="matrix-key", password="matrix-pwd",
+            allowed_types=("recognizer_loop:utterance",)):
+    b = TopologyBuilder()
+    m = b.add_master("M0", use_loopback=True)
+    m.register_satellite(key, password=password,
+                         allowed_types=list(allowed_types))
+    return b, m
+
+
+def _assert_round_trip(client, m):
+    """BUS messages cross the session in both directions."""
+    seen = []
+    m.agent_protocol.bus.on("recognizer_loop:utterance", seen.append)
+    client.emit(HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message("recognizer_loop:utterance",
+                        {"utterances": ["v3 matrix ping"]}),
+    ))
+    assert _wait_for(lambda: len(seen) >= 1), "client->master BUS never arrived"
+    assert seen[0].data["utterances"] == ["v3 matrix ping"]
+
+    received = []
+    client.on_mycroft("speak", received.append)
+    peer = next(p for p in m.connected_peers())
+    m.send_to_satellite(peer, HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message("speak", {"utterance": "matrix pong"}),
+    ))
+    assert _wait_for(lambda: len(received) >= 1), "master->client BUS never arrived"
+    assert received[0].data["utterance"] == "matrix pong"
+
+
+# ─────────────────────────────────────────────── v3 ↔ v3 ──
+
+
+def test_v3_client_v3_server_noise_session_round_trip():
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client.connect(site_id="matrix-site")
+        client.wait_for_handshake(timeout=10)
+        # protocol v3 negotiated: Noise transport replaces the v2 AES session
+        assert client.noise_transport is not None
+        assert client.crypto_key is None
+        _assert_round_trip(client, m)
+        client.close()
+    finally:
+        b.stop_all()
+
+
+# ─────────────────────────────────────────────── v3 ↔ v2 ──
+
+
+def test_v3_client_v2_server_negotiates_down_to_legacy(monkeypatch):
+    # a pre-v3 server never advertises Noise support
+    monkeypatch.setattr(server_protocol, "NOISE_SUPPORTED", False)
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client.connect(site_id="matrix-site")
+        client.wait_for_handshake(timeout=10)
+        # legacy (v2) handshake: AES session key, no Noise transport
+        assert client.crypto_key is not None
+        assert client.noise_transport is None
+        _assert_round_trip(client, m)
+        client.close()
+    finally:
+        b.stop_all()
+
+
+def test_v2_client_v3_server_uses_legacy_handshake():
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd",
+                              max_protocol_version=2)
+        client.connect(site_id="matrix-site")
+        client.wait_for_handshake(timeout=10)
+        assert client.crypto_key is not None
+        assert client.noise_transport is None
+        _assert_round_trip(client, m)
+        client.close()
+    finally:
+        b.stop_all()
+
+
+# ─────────────────────────────────────── authentication failures ──
+
+
+def test_wrong_password_v3_handshake_fails_fast():
+    b, m = _master(password="right-password")
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              "wrong-password")
+        with pytest.raises(Exception):
+            client.connect(site_id="matrix-site", handshake_max_retries=1)
+        # PSK mismatch aborts cryptographically: no session of either kind,
+        # and no silent fallback to the legacy handshake
+        assert not client.handshake_event.is_set()
+        assert client.noise_transport is None
+        assert client.crypto_key is None
+        assert not any("v3-matrix-client" in p for p in m.connected_peers())
+        client.close()
+    finally:
+        b.stop_all()
+
+
+def test_tampered_negotiation_aborts_handshake(monkeypatch):
+    # simulate a MITM rewriting the server's advertised parameters (a
+    # downgrade attempt): the client builds its Noise prologue from the
+    # tampered payload, the server from what it actually sent — the
+    # handshake transcripts disagree and the handshake MUST abort
+    original = HiveMindSlaveProtocol.start_noise_handshake
+
+    def tampered(self, server_payload):
+        doctored = dict(server_payload)
+        doctored["max_protocol_version"] = 3
+        doctored["binarize"] = not doctored.get("binarize", False)
+        return original(self, doctored)
+
+    monkeypatch.setattr(HiveMindSlaveProtocol, "start_noise_handshake", tampered)
+
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        with pytest.raises(Exception):
+            client.connect(site_id="matrix-site", handshake_max_retries=1)
+        assert not client.handshake_event.is_set()
+        assert client.noise_transport is None
+        assert not any("v3-matrix-client" in p for p in m.connected_peers())
+        client.close()
+    finally:
+        b.stop_all()
+
+
+# ────────────────────────────────────────────── replay resistance ──
+
+
+def test_replayed_v3_transport_message_is_rejected():
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client.connect(site_id="matrix-site")
+        client.wait_for_handshake(timeout=10)
+        assert client.noise_transport is not None
+
+        seen = []
+        m.agent_protocol.bus.on("recognizer_loop:utterance", seen.append)
+
+        # capture the exact ciphertext of one legitimate transport message
+        captured = []
+        original_encrypt = client.noise_transport.encrypt_frame
+
+        def capturing_encrypt(payload):
+            ct = original_encrypt(payload)
+            captured.append(ct)
+            return ct
+
+        client.noise_transport.encrypt_frame = capturing_encrypt
+        client.emit(HiveMessage(
+            HiveMessageType.BUS,
+            payload=Message("recognizer_loop:utterance",
+                            {"utterances": ["replay me"]}),
+        ))
+        assert _wait_for(lambda: len(seen) >= 1)
+        assert captured, "no transport message captured"
+
+        # replay the captured ciphertext verbatim on the raw websocket:
+        # the server's receive nonce has moved on, AEAD fails, the message
+        # is rejected and the server tears the session down (CRYPTO-1
+        # §3.4.5). The client then auto-reconnects and completes a FRESH
+        # handshake, so observe the teardown as a replaced Noise transport
+        # (new CipherStates), not as a permanently absent peer.
+        old_transport = client.noise_transport
+        client.client.send(captured[0], ABNF.OPCODE_BINARY)
+
+        assert _wait_for(
+            lambda: client.noise_transport is not old_transport,
+            timeout=15,
+        ), "server did not tear down the session after a replayed message"
+        time.sleep(0.5)
+        assert len(seen) == 1, "replayed message was delivered twice"
+        client.close()
+    finally:
+        b.stop_all()

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -5,7 +5,9 @@ import unittest
 from hivemind_bus_client.noise import (
     NOISE_PATTERN_KK,
     NOISE_PATTERN_XX,
+    NOISE_SUITE_AESGCM,
     NOISE_SUITE_CHACHA,
+    NOISE_SUITES,
     NOISE_SUPPORTED,
     NoiseHandshakeFailed,
     NoiseTransport,
@@ -43,6 +45,26 @@ class TestNegotiationHelpers(unittest.TestCase):
         self.assertIsNone(select_noise_options([NOISE_PATTERN_XX], []))
         self.assertIsNone(select_noise_options(["bogus"], ["bogus"]))
 
+    def test_suite_registry_offers_both_chacha_first(self):
+        # CRYPTO-1 §3.4.1: ChaChaPoly MUST (preferred), AES-GCM MAY (second)
+        self.assertEqual(NOISE_SUITES,
+                         [NOISE_SUITE_CHACHA, NOISE_SUITE_AESGCM])
+
+    def test_select_prefers_chacha_regardless_of_server_order(self):
+        patterns = [NOISE_PATTERN_XX]
+        self.assertEqual(
+            select_noise_options(patterns,
+                                 [NOISE_SUITE_AESGCM, NOISE_SUITE_CHACHA]),
+            (NOISE_PATTERN_XX, NOISE_SUITE_CHACHA))
+        # an AES-GCM-only peer (e.g. Web Crypto) still negotiates
+        self.assertEqual(
+            select_noise_options(patterns, [NOISE_SUITE_AESGCM]),
+            (NOISE_PATTERN_XX, NOISE_SUITE_AESGCM))
+
+    def test_select_suite_mismatch(self):
+        self.assertIsNone(select_noise_options([NOISE_PATTERN_XX],
+                                               ["25519_Bogus_SHA512"]))
+
     def test_prologue_binds_negotiation(self):
         hello = {"node_id": "server", "pubkey": "abc"}
         handshake = {"max_protocol_version": 3, "noise": {"patterns": ["XXpsk2"]}}
@@ -65,13 +87,17 @@ class TestHandshakeAndTransport(unittest.TestCase):
                               {"max_protocol_version": 3},
                               "Noise_XXpsk2_25519_ChaChaPoly_SHA256")
 
-    def _handshake_pair(self, password_b="s3cr3t", prologue_b=None):
-        common = dict(pattern=NOISE_PATTERN_XX, suite=NOISE_SUITE_CHACHA,
+    def _handshake_pair(self, password_b="s3cr3t", prologue_b=None,
+                        suite=NOISE_SUITE_CHACHA):
+        prologue = build_prologue(
+            {"node_id": "server"}, {"max_protocol_version": 3},
+            noise_protocol_name(NOISE_PATTERN_XX, suite))
+        common = dict(pattern=NOISE_PATTERN_XX, suite=suite,
                       node_id="server")
         alice = start_noise_handshake(initiator=True, password="s3cr3t",
-                                      prologue=self.PROLOGUE, **common)
+                                      prologue=prologue, **common)
         bob = start_noise_handshake(initiator=False, password=password_b,
-                                    prologue=prologue_b or self.PROLOGUE,
+                                    prologue=prologue_b or prologue,
                                     **common)
         return alice, bob
 
@@ -95,6 +121,29 @@ class TestHandshakeAndTransport(unittest.TestCase):
         self.assertEqual(tb.decrypt_frame(ct), '{"msg_type": "bus"}')
         ct = tb.encrypt_frame(b"\x00\x01binary")
         self.assertEqual(ta.decrypt_frame(ct), b"\x00\x01binary")
+
+    def test_xxpsk2_aesgcm_round_trip(self):
+        # the AES-GCM suite (Web Crypto / HiveMind-js peers) completes the
+        # handshake and encrypts/decrypts transport frames both ways
+        alice, bob = self._handshake_pair(suite=NOISE_SUITE_AESGCM)
+        ta, tb = self._complete(alice, bob)
+        self.assertTrue(ta.remote_static_key)
+        self.assertTrue(tb.remote_static_key)
+        ct = ta.encrypt_frame('{"msg_type": "bus"}')
+        self.assertEqual(tb.decrypt_frame(ct), '{"msg_type": "bus"}')
+        ct = tb.encrypt_frame(b"\x00\x01binary")
+        self.assertEqual(ta.decrypt_frame(ct), b"\x00\x01binary")
+
+    def test_suite_mismatch_between_peers_aborts(self):
+        # peers that fixed different cipher suites cannot complete a handshake
+        common = dict(pattern=NOISE_PATTERN_XX, node_id="server",
+                      password="s3cr3t", prologue=self.PROLOGUE)
+        alice = start_noise_handshake(initiator=True,
+                                      suite=NOISE_SUITE_AESGCM, **common)
+        bob = start_noise_handshake(initiator=False,
+                                    suite=NOISE_SUITE_CHACHA, **common)
+        with self.assertRaises(Exception):
+            self._complete(alice, bob)
 
     def test_wrong_password_aborts(self):
         alice, bob = self._handshake_pair(password_b="wrong")

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,143 @@
+"""Unit tests for the protocol v3 Noise glue (hivemind_bus_client.noise)."""
+
+import unittest
+
+from hivemind_bus_client.noise import (
+    NOISE_PATTERN_KK,
+    NOISE_PATTERN_XX,
+    NOISE_SUITE_CHACHA,
+    NOISE_SUPPORTED,
+    NoiseHandshakeFailed,
+    NoiseTransport,
+    NoiseTransportFailed,
+    build_prologue,
+    canonical_json,
+    noise_protocol_name,
+    select_noise_options,
+    start_noise_handshake,
+)
+
+
+class TestNegotiationHelpers(unittest.TestCase):
+    def test_canonical_json_is_order_independent(self):
+        a = canonical_json({"b": 1, "a": [2, 3]})
+        b = canonical_json({"a": [2, 3], "b": 1})
+        self.assertEqual(a, b)
+
+    def test_noise_protocol_name(self):
+        self.assertEqual(
+            noise_protocol_name(NOISE_PATTERN_XX, NOISE_SUITE_CHACHA),
+            "Noise_XXpsk2_25519_ChaChaPoly_SHA256",
+        )
+
+    def test_select_prefers_kk_only_when_pinned(self):
+        patterns = [NOISE_PATTERN_KK, NOISE_PATTERN_XX]
+        suites = [NOISE_SUITE_CHACHA]
+        self.assertEqual(select_noise_options(patterns, suites),
+                         (NOISE_PATTERN_XX, NOISE_SUITE_CHACHA))
+        self.assertEqual(select_noise_options(patterns, suites, "aa" * 32),
+                         (NOISE_PATTERN_KK, NOISE_SUITE_CHACHA))
+
+    def test_select_returns_none_without_mutual_option(self):
+        self.assertIsNone(select_noise_options([], [NOISE_SUITE_CHACHA]))
+        self.assertIsNone(select_noise_options([NOISE_PATTERN_XX], []))
+        self.assertIsNone(select_noise_options(["bogus"], ["bogus"]))
+
+    def test_prologue_binds_negotiation(self):
+        hello = {"node_id": "server", "pubkey": "abc"}
+        handshake = {"max_protocol_version": 3, "noise": {"patterns": ["XXpsk2"]}}
+        name = noise_protocol_name(NOISE_PATTERN_XX, NOISE_SUITE_CHACHA)
+        p1 = build_prologue(hello, handshake, name)
+        # any change to the advertised parameters changes the prologue
+        tampered = dict(handshake, max_protocol_version=1)
+        self.assertNotEqual(p1, build_prologue(hello, tampered, name))
+        # both peers derive identical bytes from equal payloads
+        self.assertEqual(p1, build_prologue(dict(hello), dict(handshake), name))
+
+
+class TestHandshakeAndTransport(unittest.TestCase):
+    """The noise primitive is a declared dependency: these must always run."""
+
+    def test_noise_primitive_installed(self):
+        self.assertTrue(NOISE_SUPPORTED)
+
+    PROLOGUE = build_prologue({"node_id": "server"},
+                              {"max_protocol_version": 3},
+                              "Noise_XXpsk2_25519_ChaChaPoly_SHA256")
+
+    def _handshake_pair(self, password_b="s3cr3t", prologue_b=None):
+        common = dict(pattern=NOISE_PATTERN_XX, suite=NOISE_SUITE_CHACHA,
+                      node_id="server")
+        alice = start_noise_handshake(initiator=True, password="s3cr3t",
+                                      prologue=self.PROLOGUE, **common)
+        bob = start_noise_handshake(initiator=False, password=password_b,
+                                    prologue=prologue_b or self.PROLOGUE,
+                                    **common)
+        return alice, bob
+
+    def _complete(self, alice, bob):
+        m1 = alice.write_message(b"hi")
+        bob.read_message(m1)
+        m2 = bob.write_message(b"ho")
+        alice.read_message(m2)
+        m3 = alice.write_message(b"")
+        bob.read_message(m3)
+        return NoiseTransport(alice), NoiseTransport(bob)
+
+    def test_xxpsk2_round_trip_and_static_key_exchange(self):
+        alice, bob = self._handshake_pair()
+        ta, tb = self._complete(alice, bob)
+        # learned static keys are exposed for TOFU pinning
+        self.assertTrue(ta.remote_static_key)
+        self.assertTrue(tb.remote_static_key)
+        # JSON frames round-trip as str, binary frames as bytes
+        ct = ta.encrypt_frame('{"msg_type": "bus"}')
+        self.assertEqual(tb.decrypt_frame(ct), '{"msg_type": "bus"}')
+        ct = tb.encrypt_frame(b"\x00\x01binary")
+        self.assertEqual(ta.decrypt_frame(ct), b"\x00\x01binary")
+
+    def test_wrong_password_aborts(self):
+        alice, bob = self._handshake_pair(password_b="wrong")
+        with self.assertRaises(Exception):
+            self._complete(alice, bob)
+
+    def test_prologue_mismatch_aborts(self):
+        tampered = build_prologue({"node_id": "server"},
+                                  {"max_protocol_version": 1},  # downgraded
+                                  "Noise_XXpsk2_25519_ChaChaPoly_SHA256")
+        alice, bob = self._handshake_pair(prologue_b=tampered)
+        with self.assertRaises(Exception):
+            self._complete(alice, bob)
+
+    def test_replay_is_rejected(self):
+        ta, tb = self._complete(*self._handshake_pair())
+        ct = ta.encrypt_frame("one")
+        self.assertEqual(tb.decrypt_frame(ct), "one")
+        # decrypting the same ciphertext again fails: the receive nonce
+        # counter has advanced (CRYPTO-1 §3.4.5 replay resistance)
+        with self.assertRaises(NoiseTransportFailed):
+            tb.decrypt_frame(ct)
+
+    def test_tampered_ciphertext_is_rejected(self):
+        ta, tb = self._complete(*self._handshake_pair())
+        ct = bytearray(ta.encrypt_frame("payload"))
+        ct[-1] ^= 0x01
+        with self.assertRaises(NoiseTransportFailed):
+            tb.decrypt_frame(bytes(ct))
+
+    def test_out_of_order_delivery_is_rejected(self):
+        ta, tb = self._complete(*self._handshake_pair())
+        first = ta.encrypt_frame("first")
+        second = ta.encrypt_frame("second")
+        with self.assertRaises(NoiseTransportFailed):
+            tb.decrypt_frame(second)  # skipped ahead of `first`
+        del first
+
+    def test_transport_requires_finished_handshake(self):
+        alice, _ = self._handshake_pair()
+        with self.assertRaises(NoiseHandshakeFailed):
+            NoiseTransport(alice)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The alpha publish fails with `400 Can't have direct dependency: hivemind-core @ git+...` — PyPI forbids direct URL deps in uploaded package metadata. This has blocked every alpha since the v3 e2e matrix landed (PyPI frozen at 0.9.2a1).

Move the Noise-capable hivemind-core **git ref** out of the `e2e` extra and into the build-tests workflow's `pre_install_pip`, so e2e still installs it (via pip) while the published wheel carries no URL dependency. Revert to a normal version pin once hivemind-core protocol v3 releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)