### PR TITLE
fix: async client negotiates v3 Noise + awaits handshake emit

### DIFF
--- a/hivemind_bus_client/async_client.py
+++ b/hivemind_bus_client/async_client.py
@@ -48,6 +48,7 @@ from hivemind_bus_client.encryption import (SupportedCiphers,
                                             decrypt_from_json, encrypt_as_json,
                                             encrypt_bin, hybrid_encrypt)
 from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.noise import NoiseTransportFailed
 from hivemind_bus_client.keepalive import websocket_keepalive_options
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.serialization import (HiveMindBinaryPayloadType,
@@ -148,11 +149,21 @@ class AsyncHiveMessageBusClient:
                  internal_bus=None,
                  bin_callbacks: Optional[BinaryDataCallbacks] = None,
                  websocket_ping_interval: Optional[float] = None,
-                 websocket_ping_timeout: Optional[float] = None):
+                 websocket_ping_timeout: Optional[float] = None,
+                 max_protocol_version: int = 3):
         if websockets is None:
             raise ImportError(_MISSING_WEBSOCKETS)
 
         self.bin_callbacks = bin_callbacks or BinaryDataCallbacks()
+        # highest HiveMind protocol version this client will negotiate
+        # (HIVEMIND-WIRE-1 §2), mirroring the sync client. 3 -> Noise
+        # handshake when the server also supports it; servers capped at 2 or
+        # lower fall back to the legacy handshake transparently. The shared
+        # HiveMindSlaveProtocol._should_use_noise reads this attribute, so it
+        # MUST exist for v3 Noise to be negotiated. Set to 2 to force legacy.
+        self.max_protocol_version = max_protocol_version
+        # established protocol v3 Noise session (None on v2 and below)
+        self.noise_transport = None
         self.json_encoding = SupportedEncodings.JSON_HEX
         self.cipher = SupportedCiphers.AES_GCM
 
@@ -313,6 +324,7 @@ class AsyncHiveMessageBusClient:
         """Cleanly close the WebSocket and stop the receive loop."""
         self.handshake_event.clear()
         self.crypto_key = None
+        self.noise_transport = None
         self.connected_event.clear()
         if self._ws is not None:
             try:
@@ -377,6 +389,7 @@ class AsyncHiveMessageBusClient:
             LOG.debug(f"WebSocket closed: {e!r}")
             self.handshake_event.clear()
             self.crypto_key = None
+            self.noise_transport = None
             self.connected_event.clear()
             self.emitter.emit("close")
         except asyncio.CancelledError:
@@ -386,11 +399,28 @@ class AsyncHiveMessageBusClient:
             self.emitter.emit("error")
             self.handshake_event.clear()
             self.crypto_key = None
+            self.noise_transport = None
             self.connected_event.clear()
 
     def on_message(self, message):
         """Decode + dispatch a single WS frame. Mirrors the sync client."""
-        if self.crypto_key:
+        if self.noise_transport is not None:
+            # protocol v3: every post-handshake message is a Noise transport
+            # message; there is no cleartext v3 session (CRYPTO-1 §3.4.5)
+            if not isinstance(message, (bytes, bytearray)):
+                LOG.error("dropping non-Noise message received on a "
+                          "protocol v3 session")
+                return
+            try:
+                message = self.noise_transport.decrypt_frame(bytes(message))
+            except NoiseTransportFailed:
+                # tampered / replayed / out-of-order — MUST reject; the
+                # receive counter is now out of sync so the session is dead
+                LOG.exception("rejecting invalid Noise transport message, "
+                              "closing connection")
+                asyncio.ensure_future(self.close())
+                return
+        elif self.crypto_key:
             if isinstance(message, (bytes, bytearray)):
                 message = decrypt_bin(self.crypto_key, message, cipher=self.cipher)
             elif "ciphertext" in message:
@@ -504,7 +534,11 @@ class AsyncHiveMessageBusClient:
                                        compressed=self.compress,
                                        binary_type=binary_type,
                                        hivemeta=message.metadata)
-                if self.crypto_key:
+                if self.noise_transport is not None:
+                    # protocol v3: Noise transport CipherState (replay
+                    # resistant sequential nonces) replaces the v2 AEAD
+                    payload_bytes = self.noise_transport.encrypt_frame(bitstr.bytes)
+                elif self.crypto_key:
                     payload_bytes = encrypt_bin(self.crypto_key, bitstr.bytes,
                                                 cipher=self.cipher)
                 else:
@@ -512,6 +546,17 @@ class AsyncHiveMessageBusClient:
                 await self._ws.send(payload_bytes)
             else:
                 ws_payload = serialize_message(message)
+                # HANDSHAKE frames carry the Noise handshake itself and are
+                # ALWAYS cleartext — they must never be transport-encrypted.
+                # The sync client relies on timing for this (noise_transport is
+                # still None when the final handshake frame is sent); on the
+                # async client emit is deferred onto the loop and runs after
+                # noise_transport is assigned, so guard on the type explicitly.
+                if (self.noise_transport is not None
+                        and message.msg_type != HiveMessageType.HANDSHAKE):
+                    # v3 sessions are always encrypted, HELLO included
+                    await self._ws.send(self.noise_transport.encrypt_frame(ws_payload))
+                    return
                 if self.crypto_key:
                     ws_payload = encrypt_as_json(
                         self.crypto_key, ws_payload,

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import random
@@ -279,6 +280,23 @@ class HiveMindSlaveProtocol:
             return f"{cfg.host}:{cfg.port}"
         return self.internal_protocol.node_id or "unknown"
 
+    def _emit(self, message: HiveMessage):
+        """Send a protocol frame through the bound client.
+
+        The handshake state machine is shared by both the threading client
+        (:class:`~hivemind_bus_client.client.HiveMessageBusClient`, whose
+        ``emit`` is synchronous) and the asyncio client
+        (:class:`~hivemind_bus_client.async_client.AsyncHiveMessageBusClient`,
+        whose ``emit`` is a coroutine). Calling ``self.hm.emit(...)`` directly
+        would leave the coroutine un-awaited on the async client, so the frame
+        would never reach the wire and the handshake would hang. Detect the
+        coroutine and schedule it on the running receive loop; on the sync
+        client ``emit`` returns ``None`` and nothing extra happens.
+        """
+        result = self.hm.emit(message)
+        if asyncio.iscoroutine(result):
+            asyncio.ensure_future(result)
+
     def _should_use_noise(self, payload: dict) -> bool:
         """True when both peers are v3-capable and can run the Noise handshake.
 
@@ -340,7 +358,7 @@ class HiveMindSlaveProtocol:
             LOG.exception("failed to start Noise handshake")
             self._abort_noise("failed to initialize Noise handshake")
             return
-        self.hm.emit(HiveMessage(HiveMessageType.HANDSHAKE, {
+        self._emit(HiveMessage(HiveMessageType.HANDSHAKE, {
             "noise": {"pattern": pattern, "suite": suite,
                       "msg": msg1.hex()}}))
 
@@ -364,7 +382,7 @@ class HiveMindSlaveProtocol:
             if not self.noise_handshake.handshake_finished:
                 # XXpsk2 message 3: our (encrypted) static key + final DH mix
                 msg3 = self.noise_handshake.write_message(b"")
-                self.hm.emit(HiveMessage(HiveMessageType.HANDSHAKE,
+                self._emit(HiveMessage(HiveMessageType.HANDSHAKE,
                                          {"noise": {"msg": msg3.hex()}}))
             transport = NoiseTransport(self.noise_handshake)
         except Exception:
@@ -400,7 +418,7 @@ class HiveMindSlaveProtocol:
 
         # first Noise transport message: session data + site id + pubkey
         sess = Session(self.hm.session_id)
-        self.hm.emit(HiveMessage(HiveMessageType.HELLO,
+        self._emit(HiveMessage(HiveMessageType.HELLO,
                                  {"pubkey": self.identity.public_key,
                                   "session": sess.serialize(),
                                   "site_id": self.site_id}))
@@ -412,7 +430,9 @@ class HiveMindSlaveProtocol:
         self.noise_handshake = None
         self.hm.noise_transport = None
         try:
-            self.hm.close()
+            result = self.hm.close()
+            if asyncio.iscoroutine(result):
+                asyncio.ensure_future(result)
         except Exception:
             pass
 
@@ -440,7 +460,7 @@ class HiveMindSlaveProtocol:
         else:
             payload["pubkey"] = self.handshake.pubkey
 
-        self.hm.emit(HiveMessage(HiveMessageType.HANDSHAKE, payload))
+        self._emit(HiveMessage(HiveMessageType.HANDSHAKE, payload))
 
     def receive_handshake(self, envelope):
         if self.pswd_handshake is not None:
@@ -464,7 +484,7 @@ class HiveMindSlaveProtocol:
         msg = HiveMessage(HiveMessageType.HELLO, {"pubkey": self.identity.public_key,
                                                   "session": sess.serialize(),
                                                   "site_id": self.site_id})
-        self.hm.emit(msg)
+        self._emit(msg)
         self.hm.handshake_event.set()
 
     def handle_handshake(self, message: HiveMessage):
@@ -654,7 +674,7 @@ class HiveMindSlaveProtocol:
         own_ping_outer = HiveMessage(HiveMessageType.PROPAGATE, payload=own_ping_inner)
 
         LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
-        self.hm.emit(own_ping_outer)
+        self._emit(own_ping_outer)
 
     @staticmethod
     def _is_stream_end(message: HiveMessage) -> bool:

--- a/tests/e2e/test_protocol_v3_matrix_async.py
+++ b/tests/e2e/test_protocol_v3_matrix_async.py
@@ -1,0 +1,132 @@
+"""Protocol v2/v3 handshake matrix for the asyncio client.
+
+Async analogue of ``test_protocol_v3_matrix.py``, driving a REAL
+websocket against a REAL hivemind-core master (via hivescope's
+``TopologyBuilder``) with :class:`AsyncHiveMessageBusClient`:
+
+- v3 async client ↔ v3 server: Noise session established, BUS messages
+  round-trip both ways over the Noise transport.
+- v3 async client ↔ v2 server (Noise disabled): negotiates down to the
+  legacy AES handshake, BUS messages round-trip.
+
+These reproduce the two shipped bugs that made the ``[async]`` extra
+unusable against a protocol-v3 hub:
+
+1. ``AsyncHiveMessageBusClient`` did not define ``max_protocol_version``,
+   so ``HiveMindSlaveProtocol._should_use_noise`` read the ``2`` default
+   and Noise was never negotiated.
+2. The handshake state machine emitted its frames with a bare
+   ``self.hm.emit(...)`` — a never-awaited coroutine on the async client —
+   so the handshake frame never reached the wire and ``connect()`` hung
+   forever.
+"""
+
+import asyncio
+
+import pytest
+from ovos_bus_client.message import Message
+
+import hivemind_core.protocol as server_protocol
+from hivemind_bus_client.async_client import AsyncHiveMessageBusClient
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivescope import TopologyBuilder
+
+
+async def _wait_for(condition, timeout: float = 10.0, interval: float = 0.05) -> bool:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if condition():
+            return True
+        await asyncio.sleep(interval)
+    return False
+
+
+def _make_async_client(url, key, password, name="v3-async-client",
+                       max_protocol_version=3):
+    host, port = url.replace("ws://", "").rstrip("/").split(":")
+    port = int(port)
+    identity = NodeIdentity()
+    identity.access_key = key
+    identity.password = password
+    identity.default_master = f"ws://{host}"
+    identity.default_port = port
+    identity.name = name
+    identity.site_id = f"{name}-site"
+    return AsyncHiveMessageBusClient(
+        key=key, password=password,
+        host=f"ws://{host}", port=port,
+        useragent=name, self_signed=False,
+        identity=identity,
+        max_protocol_version=max_protocol_version,
+    )
+
+
+def _master(key="async-matrix-key", password="async-matrix-pwd",
+            allowed_types=("recognizer_loop:utterance",)):
+    b = TopologyBuilder()
+    m = b.add_master("M0", use_loopback=True)
+    m.register_satellite(key, password=password,
+                         allowed_types=list(allowed_types))
+    return b, m
+
+
+async def _assert_round_trip(client, m):
+    """BUS messages cross the session in both directions."""
+    seen = []
+    m.agent_protocol.bus.on("recognizer_loop:utterance", seen.append)
+    await client.emit(HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message("recognizer_loop:utterance",
+                        {"utterances": ["async v3 ping"]}),
+    ))
+    assert await _wait_for(lambda: len(seen) >= 1), "client->master BUS never arrived"
+    assert seen[0].data["utterances"] == ["async v3 ping"]
+
+    received = []
+    client.on_mycroft("speak", received.append)
+    peer = next(p for p in m.connected_peers())
+    m.send_to_satellite(peer, HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message("speak", {"utterance": "async pong"}),
+    ))
+    assert await _wait_for(lambda: len(received) >= 1), "master->client BUS never arrived"
+    assert received[0].data["utterance"] == "async pong"
+
+
+@pytest.mark.asyncio
+async def test_async_v3_client_v3_server_noise_session_round_trip():
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_async_client(m.network_protocol.url,
+                                    "async-matrix-key", "async-matrix-pwd")
+        # would hang forever before the fix
+        await asyncio.wait_for(client.connect(site_id="matrix-site"), timeout=15)
+        # protocol v3 negotiated: Noise transport replaces the v2 AES session
+        assert client.noise_transport is not None
+        assert client.crypto_key is None
+        await _assert_round_trip(client, m)
+        await client.close()
+    finally:
+        b.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_async_v3_client_v2_server_negotiates_down_to_legacy(monkeypatch):
+    # a pre-v3 server never advertises Noise support
+    monkeypatch.setattr(server_protocol, "NOISE_SUPPORTED", False)
+    b, m = _master()
+    try:
+        b.start_all()
+        client = _make_async_client(m.network_protocol.url,
+                                    "async-matrix-key", "async-matrix-pwd")
+        await asyncio.wait_for(client.connect(site_id="matrix-site"), timeout=15)
+        # legacy (v2) handshake: AES session key, no Noise transport
+        assert client.crypto_key is not None
+        assert client.noise_transport is None
+        await _assert_round_trip(client, m)
+        await client.close()
+    finally:
+        b.stop_all()

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -35,6 +35,8 @@ def _bare_client(**overrides) -> AsyncHiveMessageBusClient:
     bus.json_encoding = "JSON_HEX"
     bus.cipher = "AES_GCM"
     bus.crypto_key = None
+    bus.noise_transport = None
+    bus.max_protocol_version = 3
     bus.compress = False
     bus.binarize = False
     bus.websocket_ping_interval = None


### PR DESCRIPTION
## Problem

`AsyncHiveMessageBusClient` could not complete a handshake against a protocol-v3 `hivemind-core` hub (4.7.0a1), making the published `[async]` extra unusable. An isolated probe confirmed it: a sync client connects via Noise XXpsk2, the async client stalls forever.

## Root cause — two shipped bugs

1. **Noise never negotiated.** The shared `HiveMindSlaveProtocol._should_use_noise` reads `self.hm.max_protocol_version`, but the async client never defined it → it fell back to the `2` default and refused v3. (The sync `HiveMessageBusClient` defines it; the async one did not.) The async client was also missing the entire `noise_transport` session path (encrypt/decrypt) that the sync client has, so even a negotiated v3 session could not carry traffic.

2. **Handshake frame never sent.** The handshake state machine sends frames with a bare `self.hm.emit(...)`. On the async client `emit` is a **coroutine**, so it was never awaited → the frame never reached the wire → `connect()` hung forever.

## Fix

- Add `max_protocol_version` (default 3) to `AsyncHiveMessageBusClient`, mirroring the sync client, plus `noise_transport` state and the Noise encrypt/decrypt branches in `on_message`/`emit`.
- Route the protocol's handshake/hello/ping emits through a new `HiveMindSlaveProtocol._emit()`: it schedules the coroutine on the running receive loop for the async client and is a transparent pass-through for the sync client (whose `emit` returns `None`). HANDSHAKE frames are explicitly kept cleartext because the deferred async emit runs *after* `noise_transport` is assigned.

The fix lives in the shared layer; the sync client is unchanged in behavior (its v3 matrix stays green).

## Test / evidence

New real e2e in `tests/e2e/test_protocol_v3_matrix_async.py` drives `AsyncHiveMessageBusClient` against a live `hivemind-core` master (via hivescope's `TopologyBuilder`): v3 Noise session round-trip, and v2 legacy-fallback round-trip (server `NOISE_SUPPORTED=False`).

Before/after against a real hub:

- **Before:** async v3 handshake never completes — `connect()` hangs; with the partial-fix state the handshake completes but the round-trip fails at the server with `Failed to decode message ... incorrect header check` (msg3 wrongly encrypted / traffic not Noise-framed).
- **After:** both async e2e cases pass; sync v3 matrix (6 tests) stays green; async unit suite green.

```
tests/e2e/test_protocol_v3_matrix_async.py ..            2 passed
tests/e2e/test_protocol_v3_matrix.py       ......        6 passed
tests/ (unit, async)                                     all green
```

(The 3 pre-existing `test_serialization` interop failures are an unrelated stale local `vectors.json` missing the `bitstring_interop` key — untouched by this PR.)

## Downstream

Unblocks HiveMind-deltachat-bridge #7, which was draft-blocked on the async client being able to reach a v3 hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)