### PR TITLE
Allow poorman-handshake 2

### DIFF
--- a/tests/e2e/test_encryption.py
+++ b/tests/e2e/test_encryption.py
@@ -4,6 +4,8 @@ from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.identity import NodeIdentity
 from hivescope import TopologyBuilder
 
+STRONG_PASSWORD = "encryption-horse-battery-staple-92"
+
 
 def _make_client(url, key, password, name="test-client"):
     host, port = url.replace("ws://", "").rstrip("/").split(":")
@@ -26,10 +28,10 @@ def _make_client(url, key, password, name="test-client"):
 def test_client_and_master_agree_on_encryption():
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("test-key", password="test-password")
+    m.register_satellite("test-key", password=STRONG_PASSWORD)
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "test-key", "test-password")
+        client = _make_client(m.network_protocol.url, "test-key", STRONG_PASSWORD)
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
         # the session must be encrypted: v2 AES session key or the negotiated

--- a/tests/e2e/test_handshake.py
+++ b/tests/e2e/test_handshake.py
@@ -6,6 +6,8 @@ from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.identity import NodeIdentity
 from hivescope import TopologyBuilder
 
+STRONG_PASSWORD = "correct-horse-battery-staple-92"
+
 
 def _make_client(url: str, key: str, password: str,
                  name: str = "test-client") -> HiveMessageBusClient:
@@ -29,10 +31,10 @@ def _make_client(url: str, key: str, password: str,
 def test_client_completes_handshake_via_websocket():
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("test-key", password="test-password")
+    m.register_satellite("test-key", password=STRONG_PASSWORD)
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "test-key", "test-password")
+        client = _make_client(m.network_protocol.url, "test-key", STRONG_PASSWORD)
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
         assert client.handshake_event.is_set()
@@ -50,10 +52,10 @@ def test_client_completes_handshake_via_websocket():
 def test_client_crypto_key_set_after_handshake():
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("test-key", password="test-password")
+    m.register_satellite("test-key", password=STRONG_PASSWORD)
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "test-key", "test-password")
+        client = _make_client(m.network_protocol.url, "test-key", STRONG_PASSWORD)
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
         # encrypted session established: v2 crypto_key or v3 Noise transport

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -7,6 +7,10 @@ from hivemind_bus_client.identity import NodeIdentity
 
 from hivescope import TopologyBuilder
 
+PASSWORD_A = "client-a-horse-battery-staple-92"
+PASSWORD_B = "client-b-horse-battery-staple-92"
+RECONNECT_PASSWORD = "reconnect-horse-battery-staple-92"
+
 
 def _make_client(url, key, password, name):
     host, port = url.replace("ws://", "").rstrip("/").split(":")
@@ -29,12 +33,12 @@ def _make_client(url, key, password, name):
 def test_two_clients_register_independently():
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("key-a", password="pw-a")
-    m.register_satellite("key-b", password="pw-b")
+    m.register_satellite("key-a", password=PASSWORD_A)
+    m.register_satellite("key-b", password=PASSWORD_B)
     try:
         b.start_all()
-        c1 = _make_client(m.network_protocol.url, "key-a", "pw-a", "client-a")
-        c2 = _make_client(m.network_protocol.url, "key-b", "pw-b", "client-b")
+        c1 = _make_client(m.network_protocol.url, "key-a", PASSWORD_A, "client-a")
+        c2 = _make_client(m.network_protocol.url, "key-b", PASSWORD_B, "client-b")
         c1.connect(site_id="site-a")
         c2.connect(site_id="site-b")
         c1.wait_for_handshake(timeout=10)
@@ -52,15 +56,15 @@ def test_two_clients_register_independently():
 def test_client_can_close_and_reconnect():
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("k", password="p")
+    m.register_satellite("k", password=RECONNECT_PASSWORD)
     try:
         b.start_all()
-        c = _make_client(m.network_protocol.url, "k", "p", "reconnect")
+        c = _make_client(m.network_protocol.url, "k", RECONNECT_PASSWORD, "reconnect")
         c.connect(site_id="s1")
         c.wait_for_handshake(timeout=10)
         c.close()
 
-        c2 = _make_client(m.network_protocol.url, "k", "p", "reconnect")
+        c2 = _make_client(m.network_protocol.url, "k", RECONNECT_PASSWORD, "reconnect")
         c2.connect(site_id="s2")
         c2.wait_for_handshake(timeout=10)
         # encrypted session established: v2 crypto_key or v3 Noise transport

--- a/tests/e2e/test_round_trip.py
+++ b/tests/e2e/test_round_trip.py
@@ -9,6 +9,8 @@ from ovos_bus_client.message import Message
 
 from hivescope import TopologyBuilder
 
+ROUND_TRIP_PASSWORD = "round-trip-horse-battery-staple-92"
+
 
 def _wait_for(condition, timeout: float = 5.0, interval: float = 0.05) -> bool:
     deadline = time.monotonic() + timeout
@@ -41,11 +43,11 @@ def test_client_emit_reaches_master_agent_bus():
     """A client.emit(BUS) is delivered to the master's agent bus."""
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("rt-key", password="rt-pwd",
+    m.register_satellite("rt-key", password=ROUND_TRIP_PASSWORD,
                          allowed_types=["recognizer_loop:utterance"])
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "rt-key", "rt-pwd")
+        client = _make_client(m.network_protocol.url, "rt-key", ROUND_TRIP_PASSWORD)
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)
 
@@ -70,10 +72,10 @@ def test_master_to_client_bus_message():
     """A master-side send_to_satellite reaches the client's hive bus."""
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("rt-key", password="rt-pwd")
+    m.register_satellite("rt-key", password=ROUND_TRIP_PASSWORD)
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "rt-key", "rt-pwd",
+        client = _make_client(m.network_protocol.url, "rt-key", ROUND_TRIP_PASSWORD,
                               name="downstream")
         client.connect(site_id="loopback-site")
         client.wait_for_handshake(timeout=10)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,7 +15,7 @@ def _make_protocol() -> HiveMindSlaveProtocol:
     hm.session_id = "test-session"
     identity = MagicMock(spec=NodeIdentity)
     identity.name = "test-node"
-    identity.password = "test"
+    identity.password = "test-node-horse-battery-staple-92"
     proto = HiveMindSlaveProtocol(hm=hm, identity=identity, site_id="living-room")
     return proto
 


### PR DESCRIPTION
Fixes JarbasHiveMind/hivemind-websocket-client#138.

The newer websocket protocol stack depends on poorman-handshake 2.x, but the client still capped it below 2. That makes the listener image resolver fail when both are pinned together.

What changed:
- allow `poorman-handshake>=2.0.0a1,<3.0.0`
- update handshake/e2e fixtures to use high-entropy shared secrets

Checks:
- `python -m pytest tests/test_protocol.py tests/test_async_client.py tests/test_client.py tests/test_identity.py`

I also tried the loopback e2e handshake/encryption/multi-client/round-trip subset. It hung in topology startup after 2m18s, so I stopped it; no assertion failure was reached.
