### PR TITLE
fix: keep synchronous client reconnecting after websocket closes

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -1,7 +1,7 @@
 import json
 import ssl
 from collections.abc import Callable
-from threading import Event, Thread
+from threading import Event, Lock, Thread, current_thread
 from typing import Optional, Union
 
 import pybase64
@@ -149,6 +149,9 @@ class HiveMessageBusClient(OVOSBusClient):
         # latter does not handle a clean websocket close and can leave the
         # worker thread dead while wait_for_handshake() waits forever.
         self._stop_event = Event()
+        self._worker_lock = Lock()
+        self._worker_token: object | None = None
+        self._worker_thread: Thread | None = None
         self.websocket_ping_interval = websocket_ping_interval
         self.websocket_ping_timeout = websocket_ping_timeout
 
@@ -311,7 +314,11 @@ class HiveMessageBusClient(OVOSBusClient):
 
     def close(self):
         """Permanently stop reconnecting and close the websocket."""
-        self._stop_event.set()
+        # Serialize the stop request with worker reservation. A worker that is
+        # already shutting down retains ownership until its finally block, so
+        # a second starter cannot clear this event and revive it.
+        with self._worker_lock:
+            self._stop_event.set()
         try:
             self.client.close()
         finally:
@@ -359,19 +366,56 @@ class HiveMessageBusClient(OVOSBusClient):
         return WebSocketApp(url, on_open=self.on_open, on_close=self.on_close,
                             on_error=self.on_error, on_message=self.on_message)
 
-    def run_in_thread(self):
+    def run_in_thread(self) -> Thread:
         """Launch the reconnect lifecycle in a daemon thread."""
-        # Clear before spawning so close() cannot be overwritten by a worker
-        # that has been scheduled but has not started yet.
-        self._stop_event.clear()
-        thread = Thread(target=self._run_forever, daemon=True)
-        thread.start()
+        token = self._reserve_worker()
+        try:
+            thread = Thread(
+                target=self._run_worker, args=(token,), daemon=True
+            )
+            self._set_worker_thread(token, thread)
+            thread.start()
+        except Exception:
+            self._stop_event.set()
+            self._release_worker(token)
+            raise
         return thread
 
-    def run_forever(self):
+    def run_forever(self) -> None:
         """Run the reconnect lifecycle on the calling thread."""
-        self._stop_event.clear()
-        self._run_forever()
+        token = self._reserve_worker()
+        self._set_worker_thread(token, current_thread())
+        self._run_worker(token)
+
+    def _reserve_worker(self) -> object:
+        """Claim exclusive ownership of the reconnect lifecycle."""
+        with self._worker_lock:
+            if self._worker_token is not None:
+                raise RuntimeError(
+                    "HiveMind websocket reconnect worker is already running"
+                )
+            token = object()
+            self._worker_token = token
+            self._worker_thread = None
+            self._stop_event.clear()
+            return token
+
+    def _set_worker_thread(self, token: object, thread: Thread) -> None:
+        with self._worker_lock:
+            if self._worker_token is token:
+                self._worker_thread = thread
+
+    def _release_worker(self, token: object) -> None:
+        with self._worker_lock:
+            if self._worker_token is token:
+                self._worker_token = None
+                self._worker_thread = None
+
+    def _run_worker(self, token: object) -> None:
+        try:
+            self._run_forever()
+        finally:
+            self._release_worker(token)
 
     def _run_forever(self):
         self.started_running = True

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -132,6 +132,11 @@ class HiveMessageBusClient(OVOSBusClient):
         self.allow_self_signed = self_signed
         self.share_bus = share_bus
         self.handshake_event = Event()
+        # Own the reconnect lifecycle here instead of relying on
+        # ovos-bus-client's recursive on_error -> run_forever callback.  The
+        # latter does not handle a clean websocket close and can leave the
+        # worker thread dead while wait_for_handshake() waits forever.
+        self._stop_event = Event()
         self.websocket_ping_interval = websocket_ping_interval
         self.websocket_ping_timeout = websocket_ping_timeout
 
@@ -245,18 +250,47 @@ class HiveMessageBusClient(OVOSBusClient):
         self.retry = 5
 
     def on_error(self, *args):
-        self.connected_event.clear()
-        self.handshake_event.clear()
-        self.crypto_key = None
-        self.noise_transport = None
-        super().on_error(*args)
+        error = args[0] if len(args) == 1 else args[1]
+        # websocket-client can invoke this callback with a control frame
+        # instead of an exception. It is not a connection failure.
+        if not isinstance(error, BaseException):
+            LOG.debug("ignoring non-exception websocket error callback: %r",
+                      error)
+            return
+
+        self._clear_connection_state()
+        if isinstance(error, WebSocketConnectionClosedException):
+            LOG.warning("HiveMind websocket connection closed unexpectedly")
+        elif isinstance(error, ConnectionRefusedError):
+            LOG.warning("HiveMind websocket connection refused")
+        elif isinstance(error, ConnectionResetError):
+            LOG.warning("HiveMind websocket connection reset")
+        else:
+            LOG.warning("HiveMind websocket error: %r", error)
+            try:
+                self.emitter.emit("error", error)
+            except Exception as emitter_error:
+                LOG.exception("Failed to emit websocket error event: %s",
+                              emitter_error)
 
     def on_close(self, *args):
+        self._clear_connection_state()
+        self.emitter.emit("close")
+
+    def _clear_connection_state(self):
         self.connected_event.clear()
         self.handshake_event.clear()
         self.crypto_key = None
         self.noise_transport = None
-        super().on_close(*args)
+
+    def close(self):
+        """Permanently stop reconnecting and close the websocket."""
+        self._stop_event.set()
+        self.started_running = False
+        try:
+            self.client.close()
+        finally:
+            self._clear_connection_state()
 
     def wait_for_handshake(self, timeout=5, max_retries=None):
         """
@@ -302,13 +336,32 @@ class HiveMessageBusClient(OVOSBusClient):
 
     def run_forever(self):
         self.started_running = True
+        self._stop_event.clear()
         run_options = self._websocket_keepalive_options()
         if self.allow_self_signed:
             run_options["sslopt"] = {
                 "cert_reqs": ssl.CERT_NONE,
                 "check_hostname": False,
                 "ssl_version": ssl.PROTOCOL_TLS_CLIENT}
-        self.client.run_forever(**run_options)
+        try:
+            while not self._stop_event.is_set():
+                self.client.run_forever(**run_options)
+                self._clear_connection_state()
+                if self._stop_event.is_set():
+                    break
+
+                delay = self.retry
+                LOG.warning("HiveMind websocket disconnected; reconnecting "
+                            "in %.1f seconds", delay)
+                if self._stop_event.wait(delay):
+                    break
+
+                self.retry = min(self.retry * 2, 60)
+                self.emitter.emit("reconnecting")
+                self.client = self.create_client()
+        finally:
+            self.started_running = False
+            self._clear_connection_state()
 
     def _websocket_keepalive_options(self):
         return websocket_keepalive_options(
@@ -337,7 +390,10 @@ class HiveMessageBusClient(OVOSBusClient):
                 # receive counter is now out of sync so the session is dead
                 LOG.exception("rejecting invalid Noise transport message, "
                               "closing connection")
-                self.close()
+                # Close this connection so run_forever() establishes a fresh
+                # Noise session. Public close() is reserved for an intentional
+                # permanent shutdown.
+                self.client.close()
                 return
         elif self.crypto_key:
             # handle binary encryption

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -392,7 +392,11 @@ class HiveMessageBusClient(OVOSBusClient):
                     break
 
                 self.retry = min(self.retry * 2, 60)
-                self.emitter.emit("reconnecting")
+                try:
+                    self.emitter.emit("reconnecting")
+                except Exception as emitter_error:  # noqa: BLE001
+                    LOG.exception("Failed to emit websocket reconnecting "
+                                  "event: %s", emitter_error)
                 self.client = self.create_client()
         finally:
             self.started_running = False

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -1,28 +1,39 @@
 import json
 import ssl
-from threading import Event
-from typing import Union, Optional, Callable
+from collections.abc import Callable
+from threading import Event, Thread
+from typing import Optional, Union
 
 import pybase64
 from Cryptodome.PublicKey import RSA
-from ovos_bus_client import Message as MycroftMessage, MessageBusClient as OVOSBusClient
+from ovos_bus_client import Message as MycroftMessage
+from ovos_bus_client import MessageBusClient as OVOSBusClient
 from ovos_bus_client.session import Session
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
+from poorman_handshake.asymmetric.utils import load_RSA_key
 from pyee import EventEmitter
-from websocket import ABNF
-from websocket import WebSocketApp, WebSocketConnectionClosedException
+from websocket import ABNF, WebSocketApp, WebSocketConnectionClosedException
 
+from hivemind_bus_client.encryption import (
+    SupportedCiphers,
+    SupportedEncodings,
+    decrypt_bin,
+    decrypt_from_json,
+    encrypt_as_json,
+    encrypt_bin,
+    hybrid_encrypt,
+)
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.keepalive import websocket_keepalive_options
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
-from hivemind_bus_client.serialization import HiveMindBinaryPayloadType
-from hivemind_bus_client.serialization import get_bitstring, decode_bitstring
-from hivemind_bus_client.util import serialize_message
-from hivemind_bus_client.encryption import (encrypt_as_json, decrypt_from_json, encrypt_bin, decrypt_bin,
-                                            SupportedEncodings, SupportedCiphers, hybrid_encrypt)
 from hivemind_bus_client.noise import NoiseTransportFailed
-from poorman_handshake.asymmetric.utils import load_RSA_key, sign_RSA
+from hivemind_bus_client.serialization import (
+    HiveMindBinaryPayloadType,
+    decode_bitstring,
+    get_bitstring,
+)
+from hivemind_bus_client.util import serialize_message
 
 
 class BinaryDataCallbacks:
@@ -267,11 +278,23 @@ class HiveMessageBusClient(OVOSBusClient):
             LOG.warning("HiveMind websocket connection reset")
         else:
             LOG.warning("HiveMind websocket error: %r", error)
+            # Event handlers are application callbacks; one faulty listener
+            # must not terminate the reconnect worker.
             try:
                 self.emitter.emit("error", error)
-            except Exception as emitter_error:
+            except Exception as emitter_error:  # noqa: BLE001
                 LOG.exception("Failed to emit websocket error event: %s",
                               emitter_error)
+
+        # A callback exception does not make WebSocketApp.run_forever()
+        # return by itself. Closing only the current socket guarantees that
+        # every real error reaches the outer reconnect loop.
+        try:
+            if self.client.keep_running:
+                self.client.close()
+        except Exception as close_error:  # noqa: BLE001
+            LOG.exception("Failed to close errored websocket: %s",
+                          close_error)
 
     def on_close(self, *args):
         self._clear_connection_state()
@@ -286,7 +309,6 @@ class HiveMessageBusClient(OVOSBusClient):
     def close(self):
         """Permanently stop reconnecting and close the websocket."""
         self._stop_event.set()
-        self.started_running = False
         try:
             self.client.close()
         finally:
@@ -334,9 +356,22 @@ class HiveMessageBusClient(OVOSBusClient):
         return WebSocketApp(url, on_open=self.on_open, on_close=self.on_close,
                             on_error=self.on_error, on_message=self.on_message)
 
-    def run_forever(self):
-        self.started_running = True
+    def run_in_thread(self):
+        """Launch the reconnect lifecycle in a daemon thread."""
+        # Clear before spawning so close() cannot be overwritten by a worker
+        # that has been scheduled but has not started yet.
         self._stop_event.clear()
+        thread = Thread(target=self._run_forever, daemon=True)
+        thread.start()
+        return thread
+
+    def run_forever(self):
+        """Run the reconnect lifecycle on the calling thread."""
+        self._stop_event.clear()
+        self._run_forever()
+
+    def _run_forever(self):
+        self.started_running = True
         run_options = self._websocket_keepalive_options()
         if self.allow_self_signed:
             run_options["sslopt"] = {

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -143,6 +143,7 @@ class HiveMessageBusClient(OVOSBusClient):
         self.allow_self_signed = self_signed
         self.share_bus = share_bus
         self.handshake_event = Event()
+        self.protocol = None
         # Own the reconnect lifecycle here instead of relying on
         # ovos-bus-client's recursive on_error -> run_forever callback.  The
         # latter does not handle a clean websocket close and can leave the
@@ -305,6 +306,8 @@ class HiveMessageBusClient(OVOSBusClient):
         self.handshake_event.clear()
         self.crypto_key = None
         self.noise_transport = None
+        if self.protocol is not None:
+            self.protocol.reset_connection_state()
 
     def close(self):
         """Permanently stop reconnecting and close the websocket."""

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -148,10 +148,7 @@ class HiveMessageBusClient(OVOSBusClient):
         # ovos-bus-client's recursive on_error -> run_forever callback.  The
         # latter does not handle a clean websocket close and can leave the
         # worker thread dead while wait_for_handshake() waits forever.
-        self._stop_event = Event()
-        self._worker_lock = Lock()
-        self._worker_token: object | None = None
-        self._worker_thread: Thread | None = None
+        self._init_worker_lifecycle()
         self.websocket_ping_interval = websocket_ping_interval
         self.websocket_ping_timeout = websocket_ping_timeout
 
@@ -175,6 +172,13 @@ class HiveMessageBusClient(OVOSBusClient):
         host = self._host.replace("ws://", "").replace("wss://", "").strip()
         super().__init__(host=host, port=self._port, ssl=use_ssl,
                          emitter=EventEmitter(), session=sess)
+
+    def _init_worker_lifecycle(self) -> None:
+        """Initialize reconnect-worker ownership state."""
+        self._stop_event = Event()
+        self._worker_lock = Lock()
+        self._worker_token: object | None = None
+        self._worker_thread: Thread | None = None
 
     def init_identity(self, site_id=None):
         self.identity = self.identity or NodeIdentity()
@@ -274,6 +278,10 @@ class HiveMessageBusClient(OVOSBusClient):
             return
 
         self._clear_connection_state()
+        # Closed/refused/reset are expected reconnect triggers. Log them
+        # without emitting pyee's special "error" event, which raises when no
+        # application listener is registered. Unclassified failures remain
+        # observable to application error listeners below.
         if isinstance(error, WebSocketConnectionClosedException):
             LOG.warning("HiveMind websocket connection closed unexpectedly")
         elif isinstance(error, ConnectionRefusedError):
@@ -438,7 +446,7 @@ class HiveMessageBusClient(OVOSBusClient):
                 if self._stop_event.wait(delay):
                     break
 
-                self.retry = min(self.retry * 2, 60)
+                self.retry = min(max(self.retry, 1) * 2, 60)
                 try:
                     self.emitter.emit("reconnecting")
                 except Exception as emitter_error:  # noqa: BLE001

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -241,6 +241,23 @@ class HiveMindSlaveProtocol:
         self.hm.on(HiveMessageType.BUS, self.handle_bus)
         self.hm.on(HiveMessageType.HANDSHAKE, self.handle_handshake)
 
+    def reset_connection_state(self):
+        """Discard handshake state owned by the closed websocket.
+
+        A socket can close between Noise messages. Reusing that partial
+        handshake on the replacement socket would make the next server
+        negotiation envelope look like a malformed Noise response.
+        """
+        self.handshake = HandShake(self.identity.private_key)
+        self.pswd_handshake = None
+        self.mpubkey = ""
+        self.noise_handshake = None
+        self._noise_pattern = None
+        self._server_hello_payload = None
+        self._server_handshake_payload = None
+        if self.internal_protocol is not None:
+            self.internal_protocol.node_id = ""
+
     @property
     def node_id(self):
         # this is how ovos-core bus refers to this slave's master

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -2,10 +2,10 @@
 
 import time
 
+from hivescope import TopologyBuilder
+
 from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.identity import NodeIdentity
-
-from hivescope import TopologyBuilder
 
 PASSWORD_A = "client-a-horse-battery-staple-92"
 PASSWORD_B = "client-b-horse-battery-staple-92"

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -12,6 +12,15 @@ PASSWORD_B = "client-b-horse-battery-staple-92"
 RECONNECT_PASSWORD = "reconnect-horse-battery-staple-92"
 
 
+def _wait_for(predicate, timeout=15, interval=0.05):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
 def _make_client(url, key, password, name):
     host, port = url.replace("ws://", "").rstrip("/").split(":")
     port = int(port)
@@ -71,4 +80,38 @@ def test_client_can_close_and_reconnect():
         assert c2.crypto_key or c2.noise_transport
         c2.close()
     finally:
+        b.stop_all()
+
+
+def test_same_client_reconnects_after_clean_server_close():
+    """A normal server close must not leave the websocket worker stopped."""
+    b = TopologyBuilder()
+    m = b.add_master("M0", use_loopback=True)
+    m.register_satellite("k", password=RECONNECT_PASSWORD)
+    client = None
+    try:
+        b.start_all()
+        client = _make_client(
+            m.network_protocol.url, "k", RECONNECT_PASSWORD, "reconnect"
+        )
+        client.connect(site_id="s1")
+        client.wait_for_handshake(timeout=10)
+        old_transport = client.noise_transport
+        assert old_transport is not None
+
+        # on_open resets the production delay to five seconds; shorten only
+        # this test's next reconnect.
+        client.retry = 0.01
+        m.network_protocol._clients[0].disconnect()
+
+        assert _wait_for(
+            lambda: (
+                client.handshake_event.is_set()
+                and client.noise_transport is not None
+                and client.noise_transport is not old_transport
+            )
+        ), "same client did not establish a fresh session after server close"
+    finally:
+        if client is not None:
+            client.close()
         b.stop_all()

--- a/tests/e2e/test_multi_client.py
+++ b/tests/e2e/test_multi_client.py
@@ -102,7 +102,9 @@ def test_same_client_reconnects_after_clean_server_close():
         # on_open resets the production delay to five seconds; shorten only
         # this test's next reconnect.
         client.retry = 0.01
-        m.network_protocol._clients[0].disconnect()
+        assert _wait_for(lambda: len(m.network_protocol.clients) == 1)
+        server_connection = next(iter(m.network_protocol.clients.values()))
+        server_connection.disconnect()
 
         assert _wait_for(
             lambda: (

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,9 +107,11 @@ def _make_client(**kwargs):
     client._host = defaults["host"]
     client.init_identity()
     client.crypto_key = defaults.get("crypto_key")
+    client.noise_transport = None
     client.allow_self_signed = True
     client.share_bus = False
     client.handshake_event = Event()
+    client._stop_event = Event()
     client.websocket_ping_interval = defaults["websocket_ping_interval"]
     client.websocket_ping_timeout = defaults["websocket_ping_timeout"]
     client.compress = True
@@ -165,20 +167,49 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         client.connected_event.set()
         client.handshake_event.set()
         client.crypto_key = "some-key"
-        client.on_error(Exception("test"))
+        client.noise_transport = MagicMock()
+        error = Exception("test")
+        client.on_error(error)
         self.assertFalse(client.connected_event.is_set())
         self.assertFalse(client.handshake_event.is_set())
         self.assertIsNone(client.crypto_key)
+        self.assertIsNone(client.noise_transport)
+        mock_super_error.assert_not_called()
+        client.emitter.emit.assert_called_once_with("error", error)
+
+    def test_on_error_ignores_non_exception_callback(self):
+        client = _make_client()
+        client.connected_event.set()
+        client.handshake_event.set()
+        client.crypto_key = "some-key"
+        client.on_error(MagicMock())
+        self.assertTrue(client.connected_event.is_set())
+        self.assertTrue(client.handshake_event.is_set())
+        self.assertEqual(client.crypto_key, "some-key")
 
     def test_on_close_clears_handshake(self):
         client = _make_client()
         client.connected_event.set()
         client.handshake_event.set()
         client.crypto_key = "some-key"
+        client.noise_transport = MagicMock()
         client.on_close()
         self.assertFalse(client.connected_event.is_set())
         self.assertFalse(client.handshake_event.is_set())
         self.assertIsNone(client.crypto_key)
+        self.assertIsNone(client.noise_transport)
+        client.emitter.emit.assert_called_once_with("close")
+
+    def test_close_stops_reconnect_and_closes_socket(self):
+        client = _make_client()
+        client.connected_event.set()
+        client.handshake_event.set()
+        client.close()
+        self.assertTrue(client._stop_event.is_set())
+        self.assertFalse(client.started_running)
+        self.assertFalse(client.connected_event.is_set())
+        self.assertFalse(client.handshake_event.is_set())
+        client.client.close.assert_called_once_with()
 
 
 class TestHiveMessageBusClientKeepalive(unittest.TestCase):
@@ -224,6 +255,9 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
     def test_run_forever_passes_keepalive(self):
         client = _make_client()
         client.allow_self_signed = False
+        client.client.run_forever.side_effect = (
+            lambda **kwargs: client._stop_event.set()
+        )
         client.run_forever()
         client.client.run_forever.assert_called_once_with(
             ping_interval=25.0, ping_timeout=10.0
@@ -231,11 +265,48 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
 
     def test_run_forever_passes_keepalive_and_ssl_options(self):
         client = _make_client()
+        client.client.run_forever.side_effect = (
+            lambda **kwargs: client._stop_event.set()
+        )
         client.run_forever()
         kwargs = client.client.run_forever.call_args.kwargs
         self.assertEqual(kwargs["ping_interval"], 25.0)
         self.assertEqual(kwargs["ping_timeout"], 10.0)
         self.assertEqual(kwargs["sslopt"]["cert_reqs"], ssl.CERT_NONE)
+
+    def test_run_forever_reconnects_after_websocket_returns(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 0
+        first_socket = client.client
+        second_socket = MagicMock()
+        second_socket.run_forever.side_effect = (
+            lambda **kwargs: client._stop_event.set()
+        )
+        client.create_client = MagicMock(return_value=second_socket)
+
+        client.run_forever()
+
+        first_socket.run_forever.assert_called_once_with(
+            ping_interval=25.0, ping_timeout=10.0
+        )
+        client.create_client.assert_called_once_with()
+        second_socket.run_forever.assert_called_once_with(
+            ping_interval=25.0, ping_timeout=10.0
+        )
+        client.emitter.emit.assert_called_once_with("reconnecting")
+
+    def test_run_forever_does_not_reconnect_after_close(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.client.run_forever.side_effect = (
+            lambda **kwargs: client.close()
+        )
+        client.create_client = MagicMock()
+
+        client.run_forever()
+
+        client.create_client.assert_not_called()
 
 
 class TestHiveMessageBusClientOn(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,7 @@ from hivemind_bus_client.message import (
     HiveMessageType,
     HiveMindBinaryPayloadType,
 )
+from hivemind_bus_client.noise import NoiseTransportFailed
 
 
 class TestBinaryDataCallbacks(unittest.TestCase):
@@ -243,6 +244,21 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         thread.start.assert_called_once_with()
         client.client.run_forever.assert_not_called()
         self.assertFalse(client.started_running)
+
+
+class TestHiveMessageBusClientOnMessage(unittest.TestCase):
+    def test_invalid_noise_frame_reconnects_instead_of_stopping(self):
+        client = _make_client()
+        client.noise_transport = MagicMock()
+        client.noise_transport.decrypt_frame.side_effect = NoiseTransportFailed(
+            "invalid frame"
+        )
+
+        client.on_message(b"invalid")
+
+        client.noise_transport.decrypt_frame.assert_called_once_with(b"invalid")
+        client.client.close.assert_called_once_with()
+        self.assertFalse(client._stop_event.is_set())
 
 
 class TestHiveMessageBusClientKeepalive(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,11 @@
 """Tests for hivemind_bus_client.client — BinaryDataCallbacks, Waiters, HiveMessageBusClient."""
 import ssl
 import unittest
-from threading import Event, Lock
+from threading import Event
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
+from websocket import WebSocketConnectionClosedException
 
 from hivemind_bus_client.client import (
     BinaryDataCallbacks,
@@ -116,10 +117,7 @@ def _make_client(**kwargs):
     client.share_bus = False
     client.handshake_event = Event()
     client.protocol = None
-    client._stop_event = Event()
-    client._worker_lock = Lock()
-    client._worker_token = None
-    client._worker_thread = None
+    client._init_worker_lifecycle()
     client.websocket_ping_interval = defaults["websocket_ping_interval"]
     client.websocket_ping_timeout = defaults["websocket_ping_timeout"]
     client.compress = True
@@ -193,6 +191,20 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         client.on_error(Exception("websocket failed"))
 
         client.client.close.assert_called_once_with()
+
+    def test_on_error_keeps_expected_reconnect_failures_internal(self):
+        for error in (
+                WebSocketConnectionClosedException(),
+                ConnectionRefusedError(),
+                ConnectionResetError(),
+        ):
+            with self.subTest(error=type(error).__name__):
+                client = _make_client()
+
+                client.on_error(error)
+
+                client.emitter.emit.assert_not_called()
+                client.client.close.assert_called_once_with()
 
     def test_on_error_ignores_non_exception_callback(self):
         client = _make_client()
@@ -430,6 +442,7 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
             ping_interval=25.0, ping_timeout=10.0
         )
         client.emitter.emit.assert_called_once_with("reconnecting")
+        self.assertEqual(client.retry, 2)
 
     def test_reconnecting_listener_failure_does_not_stop_worker(self):
         client = _make_client()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 """Tests for hivemind_bus_client.client — BinaryDataCallbacks, Waiters, HiveMessageBusClient."""
 import ssl
 import unittest
-from threading import Event
+from threading import Event, Lock
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
@@ -117,6 +117,9 @@ def _make_client(**kwargs):
     client.handshake_event = Event()
     client.protocol = None
     client._stop_event = Event()
+    client._worker_lock = Lock()
+    client._worker_token = None
+    client._worker_thread = None
     client.websocket_ping_interval = defaults["websocket_ping_interval"]
     client.websocket_ping_timeout = defaults["websocket_ping_timeout"]
     client.compress = True
@@ -237,16 +240,96 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
 
         thread = client.run_in_thread()
         worker = mock_thread.call_args.kwargs["target"]
+        worker_args = mock_thread.call_args.kwargs["args"]
         client.close()
-        worker()
+        worker(*worker_args)
 
         self.assertIs(thread, mock_thread.return_value)
         mock_thread.assert_called_once_with(
-            target=client._run_forever, daemon=True
+            target=client._run_worker,
+            args=worker_args,
+            daemon=True,
         )
         thread.start.assert_called_once_with()
         client.client.run_forever.assert_not_called()
         self.assertFalse(client.started_running)
+        self.assertIsNone(client._worker_token)
+        self.assertIsNone(client._worker_thread)
+
+    @patch("hivemind_bus_client.client.Thread")
+    def test_duplicate_run_in_thread_is_rejected_while_stopping(
+            self, mock_thread):
+        client = _make_client()
+
+        client.run_in_thread()
+        worker = mock_thread.call_args.kwargs["target"]
+        worker_args = mock_thread.call_args.kwargs["args"]
+        client.close()
+
+        with self.assertRaisesRegex(RuntimeError, "already running"):
+            client.run_in_thread()
+
+        self.assertTrue(client._stop_event.is_set())
+        mock_thread.assert_called_once()
+
+        # Once the original worker has observed close() and exited, an
+        # explicit restart may claim a fresh lifecycle.
+        worker(*worker_args)
+        self.assertIsNone(client._worker_token)
+
+    @patch("hivemind_bus_client.client.Thread")
+    def test_run_forever_is_rejected_while_thread_worker_is_active(
+            self, mock_thread):
+        client = _make_client()
+
+        client.run_in_thread()
+        worker = mock_thread.call_args.kwargs["target"]
+        worker_args = mock_thread.call_args.kwargs["args"]
+
+        with self.assertRaisesRegex(RuntimeError, "already running"):
+            client.run_forever()
+
+        mock_thread.assert_called_once()
+        client.close()
+        worker(*worker_args)
+
+    def test_live_worker_rejects_duplicate_start_until_exit(self):
+        client = _make_client()
+        worker_entered = Event()
+        release_worker = Event()
+
+        def _block_socket(**kwargs):
+            worker_entered.set()
+            release_worker.wait(timeout=1)
+
+        client.client.run_forever.side_effect = _block_socket
+        thread = client.run_in_thread()
+        self.assertTrue(worker_entered.wait(timeout=1))
+
+        with self.assertRaisesRegex(RuntimeError, "already running"):
+            client.run_in_thread()
+
+        client.close()
+        release_worker.set()
+        thread.join(timeout=1)
+
+        self.assertFalse(thread.is_alive())
+        self.assertIsNone(client._worker_token)
+        self.assertIsNone(client._worker_thread)
+
+    @patch("hivemind_bus_client.client.Thread")
+    def test_worker_start_failure_releases_lifecycle(self, mock_thread):
+        client = _make_client()
+        mock_thread.return_value.start.side_effect = RuntimeError(
+            "thread start failed"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "thread start failed"):
+            client.run_in_thread()
+
+        self.assertTrue(client._stop_event.is_set())
+        self.assertIsNone(client._worker_token)
+        self.assertIsNone(client._worker_thread)
 
 
 class TestHiveMessageBusClientOnMessage(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,19 +1,22 @@
 """Tests for hivemind_bus_client.client — BinaryDataCallbacks, Waiters, HiveMessageBusClient."""
-import json
 import ssl
 import unittest
 from threading import Event
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
 
 from hivemind_bus_client.client import (
     BinaryDataCallbacks,
+    HiveMessageBusClient,
     HiveMessageWaiter,
     HivePayloadWaiter,
-    HiveMessageBusClient,
 )
-from hivemind_bus_client.message import HiveMessage, HiveMessageType, HiveMindBinaryPayloadType
+from hivemind_bus_client.message import (
+    HiveMessage,
+    HiveMessageType,
+    HiveMindBinaryPayloadType,
+)
 
 
 class TestBinaryDataCallbacks(unittest.TestCase):
@@ -79,8 +82,8 @@ class TestHivePayloadWaiter(unittest.TestCase):
 
 def _make_client(**kwargs):
     """Create HiveMessageBusClient without actually connecting or starting threads."""
-    from pyee import EventEmitter
     from ovos_utils.fakebus import FakeBus
+    from pyee import EventEmitter
 
     defaults = {
         "key": "test-key",
@@ -96,7 +99,7 @@ def _make_client(**kwargs):
     # Bypass OVOSBusClient.__init__ which starts websocket threads
     client = object.__new__(HiveMessageBusClient)
     client.bin_callbacks = defaults.pop("bin_callbacks", BinaryDataCallbacks())
-    from hivemind_bus_client.encryption import SupportedEncodings, SupportedCiphers
+    from hivemind_bus_client.encryption import SupportedCiphers, SupportedEncodings
     client.json_encoding = SupportedEncodings.JSON_HEX
     client.cipher = SupportedCiphers.AES_GCM
     client.identity = None
@@ -176,6 +179,15 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         self.assertIsNone(client.noise_transport)
         mock_super_error.assert_not_called()
         client.emitter.emit.assert_called_once_with("error", error)
+        client.client.close.assert_called_once_with()
+
+    def test_on_error_isolates_listener_failure_and_closes_socket(self):
+        client = _make_client()
+        client.emitter.emit.side_effect = RuntimeError("listener failed")
+
+        client.on_error(Exception("websocket failed"))
+
+        client.client.close.assert_called_once_with()
 
     def test_on_error_ignores_non_exception_callback(self):
         client = _make_client()
@@ -186,6 +198,7 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         self.assertTrue(client.connected_event.is_set())
         self.assertTrue(client.handshake_event.is_set())
         self.assertEqual(client.crypto_key, "some-key")
+        client.client.close.assert_not_called()
 
     def test_on_close_clears_handshake(self):
         client = _make_client()
@@ -202,14 +215,34 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
 
     def test_close_stops_reconnect_and_closes_socket(self):
         client = _make_client()
+        client.started_running = True
         client.connected_event.set()
         client.handshake_event.set()
         client.close()
         self.assertTrue(client._stop_event.is_set())
-        self.assertFalse(client.started_running)
+        # The worker owns this flag and clears it from _run_forever's finally
+        # block after it has actually stopped.
+        self.assertTrue(client.started_running)
         self.assertFalse(client.connected_event.is_set())
         self.assertFalse(client.handshake_event.is_set())
         client.client.close.assert_called_once_with()
+
+    @patch("hivemind_bus_client.client.Thread")
+    def test_run_in_thread_honors_close_before_worker_starts(self, mock_thread):
+        client = _make_client()
+
+        thread = client.run_in_thread()
+        worker = mock_thread.call_args.kwargs["target"]
+        client.close()
+        worker()
+
+        self.assertIs(thread, mock_thread.return_value)
+        mock_thread.assert_called_once_with(
+            target=client._run_forever, daemon=True
+        )
+        thread.start.assert_called_once_with()
+        client.client.run_forever.assert_not_called()
+        self.assertFalse(client.started_running)
 
 
 class TestHiveMessageBusClientKeepalive(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -345,6 +345,25 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
         )
         client.emitter.emit.assert_called_once_with("reconnecting")
 
+    def test_reconnecting_listener_failure_does_not_stop_worker(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 0
+        client.emitter.emit.side_effect = RuntimeError("listener failed")
+        second_socket = MagicMock()
+        second_socket.run_forever.side_effect = (
+            lambda **kwargs: client._stop_event.set()
+        )
+        client.create_client = MagicMock(return_value=second_socket)
+
+        client.run_forever()
+
+        client.emitter.emit.assert_called_once_with("reconnecting")
+        client.create_client.assert_called_once_with()
+        second_socket.run_forever.assert_called_once_with(
+            ping_interval=25.0, ping_timeout=10.0
+        )
+
     def test_run_forever_does_not_reconnect_after_close(self):
         client = _make_client()
         client.allow_self_signed = False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -115,6 +115,7 @@ def _make_client(**kwargs):
     client.allow_self_signed = True
     client.share_bus = False
     client.handshake_event = Event()
+    client.protocol = None
     client._stop_event = Event()
     client.websocket_ping_interval = defaults["websocket_ping_interval"]
     client.websocket_ping_timeout = defaults["websocket_ping_timeout"]
@@ -203,6 +204,7 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
 
     def test_on_close_clears_handshake(self):
         client = _make_client()
+        client.protocol = MagicMock()
         client.connected_event.set()
         client.handshake_event.set()
         client.crypto_key = "some-key"
@@ -212,6 +214,7 @@ class TestHiveMessageBusClientOnError(unittest.TestCase):
         self.assertFalse(client.handshake_event.is_set())
         self.assertIsNone(client.crypto_key)
         self.assertIsNone(client.noise_transport)
+        client.protocol.reset_connection_state.assert_called_once_with()
         client.emitter.emit.assert_called_once_with("close")
 
     def test_close_stops_reconnect_and_closes_socket(self):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -59,6 +59,32 @@ class TestHandshakeInitialization:
         debug.assert_any_call("Key size: 256bit")
 
 
+class TestConnectionState:
+    @patch("hivemind_bus_client.protocol.HandShake")
+    def test_reset_discards_partial_handshake(self, handshake_cls):
+        proto = _make_protocol()
+        proto.internal_protocol = MagicMock()
+        proto.internal_protocol.node_id = "old-master"
+        proto.pswd_handshake = MagicMock()
+        proto.mpubkey = "old-key"
+        proto.noise_handshake = MagicMock()
+        proto._noise_pattern = "XXpsk2"
+        proto._server_hello_payload = {"node_id": "old-master"}
+        proto._server_handshake_payload = {"noise": {"patterns": ["XXpsk2"]}}
+
+        proto.reset_connection_state()
+
+        handshake_cls.assert_called_once_with(proto.identity.private_key)
+        assert proto.handshake is handshake_cls.return_value
+        assert proto.pswd_handshake is None
+        assert proto.mpubkey == ""
+        assert proto.noise_handshake is None
+        assert proto._noise_pattern is None
+        assert proto._server_hello_payload is None
+        assert proto._server_handshake_payload is None
+        assert proto.internal_protocol.node_id == ""
+
+
 class TestHandlePing:
     def test_sends_responsive_ping(self):
         proto = _make_protocol()


### PR DESCRIPTION
## Problem

The synchronous client can stop reconnecting after the server cleanly closes an otherwise healthy websocket. `WebSocketApp.run_forever()` returns after a normal close, while the inherited OVOS retry path is entered only from `on_error()`. The worker exits and `wait_for_handshake()` can then wait indefinitely.

## Fix

- own retries in one iterative outer loop around `WebSocketApp.run_forever()`
- create a fresh `WebSocketApp` for every attempt
- clear connection, handshake, legacy crypto, and Noise state on every teardown
- keep retry waits interruptible with bounded exponential backoff
- make public `close()` a permanent stop while invalid Noise frames close only the current socket
- prevent `close()` from racing with worker startup
- isolate `error` and `reconnecting` application callbacks so a faulty listener cannot terminate the reconnect worker

## Architectural scope

- **Voice Satellite:** consumes this synchronous client and does not own a competing retry loop
- **OVOS base client:** handles generic bus events but does not recover a clean websocket close or HiveMind Noise state
- **Core/server:** owns admission and server-side cleanup, not a remote client's worker
- **Async client:** has a separate asyncio lifecycle and is intentionally unchanged

No wire-protocol or configuration change is required.

## Lifecycle invariants

- one iterative retry loop owns `run_forever()`
- clean close, network error, invalid Noise state, and application callback failure reach recovery
- intentional `close()` never reconnects
- a reconnect never reuses legacy or Noise session state

## Validation

- `python3 -m pytest tests --ignore=tests/e2e -q` — 358 passed, 4 skipped
- deterministic unit coverage for clean close, websocket errors, invalid Noise frames, shutdown races, permanent close, and a raising `reconnecting` listener
- manual E2E clean-close proof establishes a fresh Noise transport on the same client instance
- Python 3.10–3.14 repository matrix, lint, audit, coverage, and release preview were green before this final hardening commit

## Release impact

Bug fix suitable for the next `0.10.2` prerelease. Existing APIs and defaults are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic reconnection after unexpected or server-initiated WebSocket disconnects.
  * Ensured reconnect attempts establish a fresh session without reusing stale connection data.
  * Prevented invalid protocol messages from disrupting unrelated connections.
  * Improved connection cleanup and error handling during disconnects.
  * Explicitly closing a client now reliably stops further reconnection attempts.

* **Reliability**
  * Added safer reconnect retry behavior with controlled backoff.
  * Improved handling of connection lifecycle events and keepalive activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->