### PR TITLE
refactor: construct legacy password handshake only when selected

### DIFF
--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -503,7 +503,8 @@ class HiveMindSlaveProtocol:
             self.receive_handshake(envelope)
             LOG.debug(f"Encoding: {self.hm.json_encoding}")
             LOG.debug(f"Cipher: {self.hm.cipher}")
-            LOG.debug(f"Key size: {len(self.pswd_handshake.secret) * 8}bit")
+            active_handshake = self.pswd_handshake or self.handshake
+            LOG.debug(f"Key size: {len(active_handshake.secret) * 8}bit")
 
         # master is requesting handshake start
         else:
@@ -769,7 +770,7 @@ class HiveMindSlaveProtocol:
                 private_key = load_RSA_key(self.identity.private_key)
                 decrypted = hybrid_decrypt(private_key, pload).decode("utf-8")
                 message._payload = HiveMessage.deserialize(decrypted)
-            except Exception as e:
+            except Exception:
                 if k:
                     LOG.error("failed to decrypt INTERCOM message!")
                 else:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -218,8 +218,9 @@ class HiveMindSlaveProtocol:
         if self.identity is None:
             self.identity = self.hm.identity or NodeIdentity()
         self.handshake = HandShake(self.identity.private_key)
-        self.pswd_handshake = (PasswordHandShake(self.identity.password, min_bits=_pw_min_bits())
-                               if self.identity.password else None)
+        # PasswordHandShake is a legacy (v2) mechanism. Build it only after
+        # the server explicitly selects that fallback in handle_handshake();
+        # validating it here would apply v2 policy before v3 Noise negotiation.
 
         if bus is None:
             bus = MessageBusClient()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,6 +12,8 @@ import os
 from pathlib import Path
 import tempfile
 
+import pytest
+
 
 _xdg_tempdir = None
 
@@ -40,6 +42,27 @@ def pytest_configure(config):
     server_cfg_dir.mkdir(parents=True, exist_ok=True)
     (server_cfg_dir / "server.json").write_text(
         json.dumps({"min_protocol_version": 0}))
+
+
+@pytest.fixture(autouse=True)
+def isolated_identity_storage(monkeypatch):
+    """Force NodeIdentity below the process-wide temporary config root."""
+    import hivemind_bus_client.identity as identity_module
+    from json_database import JsonConfigXDG
+
+    # JsonConfigXDG binds its default xdg_folder when json_database is
+    # imported, before pytest_configure changes the environment. Patch the
+    # constructor used by NodeIdentity so collection order can never redirect
+    # an e2e client back to the developer's real identity file.
+    identity_config_root = Path(os.environ["XDG_CONFIG_HOME"])
+
+    def isolated_identity_config(name, *args, **kwargs):
+        kwargs["xdg_folder"] = identity_config_root
+        return JsonConfigXDG(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        identity_module, "JsonConfigXDG", isolated_identity_config
+    )
 
 
 def pytest_unconfigure(config):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -57,6 +57,7 @@ def isolated_identity_storage(monkeypatch):
     identity_config_root = Path(os.environ["XDG_CONFIG_HOME"])
 
     def isolated_identity_config(name, *args, **kwargs):
+        """Construct an identity config below this test's XDG root."""
         kwargs["xdg_folder"] = identity_config_root
         return JsonConfigXDG(name, *args, **kwargs)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,42 +1,50 @@
-"""Shared fixtures for the e2e suite.
+"""Process-wide isolation for the e2e suite.
 
 The e2e tests spin up real masters and clients in-process; both sides
 persist state under the XDG config home (node identity file, RSA .pem
-files, Noise static keys and TOFU key pins). Redirect XDG to a per-test
-temporary directory so tests never read from or write to the developer's
-real ``~/.config/hivemind`` and every test starts from a clean identity
-(no stale key pins leaking between tests).
+files, Noise static keys and TOFU key pins). Redirect XDG before pytest
+imports the test modules so import-time configuration constants cannot
+resolve to the developer's real ``~/.config/hivemind``.
 """
 
 import json
+import os
+from pathlib import Path
+import tempfile
 
-import pytest
 
-import poorman_handshake.symmetric as _pm_symmetric
+_xdg_tempdir = None
 
 
-@pytest.fixture(autouse=True)
-def isolated_xdg(monkeypatch, tmp_path):
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+def pytest_configure(config):
+    """Isolate persistent state before test collection imports HiveMind."""
+    global _xdg_tempdir
+    _xdg_tempdir = tempfile.TemporaryDirectory(
+        prefix="hivemind-websocket-client-e2e-"
+    )
+    root = Path(_xdg_tempdir.name)
+    os.environ["XDG_CONFIG_HOME"] = str(root / "config")
+    os.environ["XDG_DATA_HOME"] = str(root / "data")
+    os.environ["XDG_CACHE_HOME"] = str(root / "cache")
 
-    # The suite uses short human-readable passwords ("test-pwd", ...) that
-    # poorman-handshake's strength backstop would refuse. Disable the runtime
-    # check via the documented env var (honoured by the hivemind client/server
-    # handshake construction) and neutralise the library-level check for any
-    # component that builds a PasswordHandShake without threading min_bits
-    # through (e.g. the hivescope test harness).
-    monkeypatch.setenv("HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", "1")
-    monkeypatch.setattr(_pm_symmetric, "check_password_strength",
-                        lambda *args, **kwargs: None)
+    # Successful scenarios use strong credentials. Keep the production
+    # strength backstop enabled so weak-password tests exercise the real
+    # client/server policy instead of a monkeypatched approximation.
+    os.environ["HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK"] = "0"
 
     # Non-Noise connections top out at protocol v1, so the legacy-fallback
     # matrix rows need the server's protocol floor below the production
-    # default (min_protocol_version=2). Only this isolated test config is
+    # default (min_protocol_version=2). Only this isolated process config is
     # lowered; the shipped default is unchanged.
-    server_cfg_dir = tmp_path / "config" / "hivemind-core"
+    server_cfg_dir = root / "config" / "hivemind-core"
     server_cfg_dir.mkdir(parents=True, exist_ok=True)
     (server_cfg_dir / "server.json").write_text(
         json.dumps({"min_protocol_version": 0}))
-    return tmp_path
+
+
+def pytest_unconfigure(config):
+    """Remove the exact temporary tree created for this pytest process."""
+    global _xdg_tempdir
+    if _xdg_tempdir is not None:
+        _xdg_tempdir.cleanup()
+        _xdg_tempdir = None

--- a/tests/e2e/test_protocol_v3_matrix.py
+++ b/tests/e2e/test_protocol_v3_matrix.py
@@ -23,6 +23,10 @@ from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.protocol import HiveMindSlaveProtocol
 from hivescope import TopologyBuilder
 
+MATRIX_PASSWORD = "matrix-horse-battery-staple-92"
+RIGHT_PASSWORD = "right-horse-battery-staple-92"
+WRONG_PASSWORD = "wrong-horse-battery-staple-93"
+
 
 def _wait_for(condition, timeout: float = 10.0, interval: float = 0.05) -> bool:
     deadline = time.monotonic() + timeout
@@ -53,7 +57,7 @@ def _make_client(url, key, password, name="v3-matrix-client",
     )
 
 
-def _master(key="matrix-key", password="matrix-pwd",
+def _master(key="matrix-key", password=MATRIX_PASSWORD,
             allowed_types=("recognizer_loop:utterance",)):
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
@@ -92,7 +96,8 @@ def test_v3_client_v3_server_noise_session_round_trip():
     b, m = _master()
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              MATRIX_PASSWORD)
         client.connect(site_id="matrix-site")
         client.wait_for_handshake(timeout=10)
         # protocol v3 negotiated: Noise transport replaces the v2 AES session
@@ -113,7 +118,8 @@ def test_v3_client_v2_server_negotiates_down_to_legacy(monkeypatch):
     b, m = _master()
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              MATRIX_PASSWORD)
         client.connect(site_id="matrix-site")
         client.wait_for_handshake(timeout=10)
         # legacy (v2) handshake: AES session key, no Noise transport
@@ -129,7 +135,8 @@ def test_v2_client_v3_server_uses_legacy_handshake():
     b, m = _master()
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd",
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              MATRIX_PASSWORD,
                               max_protocol_version=2)
         client.connect(site_id="matrix-site")
         client.wait_for_handshake(timeout=10)
@@ -145,11 +152,11 @@ def test_v2_client_v3_server_uses_legacy_handshake():
 
 
 def test_wrong_password_v3_handshake_fails_fast():
-    b, m = _master(password="right-password")
+    b, m = _master(password=RIGHT_PASSWORD)
     try:
         b.start_all()
         client = _make_client(m.network_protocol.url, "matrix-key",
-                              "wrong-password")
+                              WRONG_PASSWORD)
         with pytest.raises(Exception):
             client.connect(site_id="matrix-site", handshake_max_retries=1)
         # PSK mismatch aborts cryptographically: no session of either kind,
@@ -160,6 +167,28 @@ def test_wrong_password_v3_handshake_fails_fast():
         assert not any("v3-matrix-client" in p for p in m.connected_peers())
         client.close()
     finally:
+        b.stop_all()
+
+
+def test_server_rejects_weak_password_before_noise_session():
+    """Deferring the client object does not bypass server credential policy."""
+    weak_password = "sat123"
+    b, m = _master(password=weak_password)
+    client = None
+    try:
+        b.start_all()
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              weak_password)
+        client.retry = 0.01
+        with pytest.raises(RuntimeError, match="timed out waiting for handshake"):
+            client.connect(site_id="matrix-site", handshake_max_retries=0)
+        assert not client.handshake_event.is_set()
+        assert client.noise_transport is None
+        assert client.crypto_key is None
+        assert not any("v3-matrix-client" in p for p in m.connected_peers())
+    finally:
+        if client is not None:
+            client.close()
         b.stop_all()
 
 
@@ -181,7 +210,8 @@ def test_tampered_negotiation_aborts_handshake(monkeypatch):
     b, m = _master()
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              MATRIX_PASSWORD)
         with pytest.raises(Exception):
             client.connect(site_id="matrix-site", handshake_max_retries=1)
         assert not client.handshake_event.is_set()
@@ -199,7 +229,8 @@ def test_replayed_v3_transport_message_is_rejected():
     b, m = _master()
     try:
         b.start_all()
-        client = _make_client(m.network_protocol.url, "matrix-key", "matrix-pwd")
+        client = _make_client(m.network_protocol.url, "matrix-key",
+                              MATRIX_PASSWORD)
         client.connect(site_id="matrix-site")
         client.wait_for_handshake(timeout=10)
         assert client.noise_transport is not None

--- a/tests/e2e/test_protocol_v3_matrix_async.py
+++ b/tests/e2e/test_protocol_v3_matrix_async.py
@@ -32,6 +32,8 @@ from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivescope import TopologyBuilder
 
+ASYNC_MATRIX_PASSWORD = "async-matrix-horse-battery-staple-92"
+
 
 async def _wait_for(condition, timeout: float = 10.0, interval: float = 0.05) -> bool:
     loop = asyncio.get_event_loop()
@@ -63,7 +65,7 @@ def _make_async_client(url, key, password, name="v3-async-client",
     )
 
 
-def _master(key="async-matrix-key", password="async-matrix-pwd",
+def _master(key="async-matrix-key", password=ASYNC_MATRIX_PASSWORD,
             allowed_types=("recognizer_loop:utterance",)):
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
@@ -101,7 +103,8 @@ async def test_async_v3_client_v3_server_noise_session_round_trip():
     try:
         b.start_all()
         client = _make_async_client(m.network_protocol.url,
-                                    "async-matrix-key", "async-matrix-pwd")
+                                    "async-matrix-key",
+                                    ASYNC_MATRIX_PASSWORD)
         # would hang forever before the fix
         await asyncio.wait_for(client.connect(site_id="matrix-site"), timeout=15)
         # protocol v3 negotiated: Noise transport replaces the v2 AES session
@@ -121,7 +124,8 @@ async def test_async_v3_client_v2_server_negotiates_down_to_legacy(monkeypatch):
     try:
         b.start_all()
         client = _make_async_client(m.network_protocol.url,
-                                    "async-matrix-key", "async-matrix-pwd")
+                                    "async-matrix-key",
+                                    ASYNC_MATRIX_PASSWORD)
         await asyncio.wait_for(client.connect(site_id="matrix-site"), timeout=15)
         # legacy (v2) handshake: AES session key, no Noise transport
         assert client.crypto_key is not None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -44,6 +44,20 @@ class TestHandshakeInitialization:
             with pytest.raises(WeakPasswordError):
                 proto.handle_handshake(message)
 
+    def test_pubkey_envelope_logs_asymmetric_handshake_key_size(self):
+        """Pubkey fallback must not dereference the absent password handshake."""
+        proto = _make_protocol()
+        proto.handshake = MagicMock(secret=b"k" * 32)
+        message = HiveMessage(HiveMessageType.HANDSHAKE,
+                              {"envelope": "pubkey-envelope"})
+
+        with patch.object(proto, "receive_handshake") as receive:
+            with patch("hivemind_bus_client.protocol.LOG.debug") as debug:
+                proto.handle_handshake(message)
+
+        receive.assert_called_once_with("pubkey-envelope")
+        debug.assert_any_call("Key size: 256bit")
+
 
 class TestHandlePing:
     def test_sends_responsive_ping(self):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,7 +23,7 @@ def _make_protocol() -> HiveMindSlaveProtocol:
 
 class TestHandshakeInitialization:
     def test_bind_defers_legacy_password_validation(self):
-        """A weak legacy password must not prevent protocol-v3 negotiation."""
+        """Binding must not construct a handshake that may never be used."""
         proto = _make_protocol()
         proto.identity.password = "sat123"
         bus = MagicMock()
@@ -34,7 +34,7 @@ class TestHandshakeInitialization:
         assert proto.pswd_handshake is None
 
     def test_legacy_password_handshake_still_rejects_weak_password(self):
-        """Deferring construction must not weaken the protocol-v2 fallback."""
+        """The negotiated legacy path must retain its strength policy."""
         proto = _make_protocol()
         proto.identity.password = "sat123"
         message = HiveMessage(HiveMessageType.HANDSHAKE,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,6 +7,7 @@ from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.protocol import CascadeAggregator, HiveMindSlaveProtocol
 from hivemind_bus_client.hive_map import HiveMapper, NodeInfo
 from hivemind_bus_client.identity import NodeIdentity
+from poorman_handshake.symmetric.strength import WeakPasswordError
 
 
 def _make_protocol() -> HiveMindSlaveProtocol:
@@ -18,6 +19,30 @@ def _make_protocol() -> HiveMindSlaveProtocol:
     identity.password = "test-node-horse-battery-staple-92"
     proto = HiveMindSlaveProtocol(hm=hm, identity=identity, site_id="living-room")
     return proto
+
+
+class TestHandshakeInitialization:
+    def test_bind_defers_legacy_password_validation(self):
+        """A weak legacy password must not prevent protocol-v3 negotiation."""
+        proto = _make_protocol()
+        proto.identity.password = "sat123"
+        bus = MagicMock()
+
+        with patch("hivemind_bus_client.protocol.HandShake"):
+            proto.bind(bus)
+
+        assert proto.pswd_handshake is None
+
+    def test_legacy_password_handshake_still_rejects_weak_password(self):
+        """Deferring construction must not weaken the protocol-v2 fallback."""
+        proto = _make_protocol()
+        proto.identity.password = "sat123"
+        message = HiveMessage(HiveMessageType.HANDSHAKE,
+                              {"password": True})
+
+        with patch.object(proto, "_should_use_noise", return_value=False):
+            with pytest.raises(WeakPasswordError):
+                proto.handle_handshake(message)
 
 
 class TestHandlePing:


### PR DESCRIPTION
## Summary

- remove the unused eager protocol-v2 `PasswordHandShake` construction from generic client binding
- construct it only after the server explicitly negotiates the legacy password fallback
- retain the legacy 40-bit password policy unchanged
- run E2E with production password-strength enforcement enabled

## Scope and security invariant

This is lifecycle cleanup, not a weak-password feature.

`HiveMindSlaveProtocol.bind()` runs before the server advertises a protocol version. The legacy branch in `handle_handshake()` already constructs `PasswordHandShake` when protocol v2 is actually selected, so constructing the same object during bind is premature and redundant.

Server credential policy remains independent and authoritative. A weak credential such as `sat123` is still rejected before a Noise session is established. Noise PSKs must remain high-entropy credentials; this PR does not relax client or server policy and does not make weak credentials valid for protocol v3.

## Test-harness hardening

The E2E suite previously disabled password-strength checks globally and applied XDG isolation from a fixture after test-module imports. That could both hide the real server policy and allow import-time paths to resolve to a developer's configuration.

The suite now:

- establishes an isolated XDG tree in `pytest_configure`, before test collection imports HiveMind modules
- keeps `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=0`
- uses strong credentials for successful v2/v3 rows
- proves wrong strong credentials fail cryptographically
- proves a weak credential is rejected by the server with no legacy or Noise session

## Validation

- `python3 -m pytest tests/test_protocol.py -q` — 21 passed
- `python3 -m pytest tests --ignore=tests/e2e -q` — 352 passed, 4 skipped
- `python3 -m pytest tests/e2e/test_protocol_v3_matrix.py -q` — 7 passed
- isolated weak-password proof: handshake false, Noise transport absent, no connected peer

## Release impact

Internal initialization cleanup plus test-security hardening. Protocol-v2 compatibility and production credential policy are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol negotiation so legacy password authentication is only initialized when required.
  * Preserved password-strength validation during legacy authentication.
  * Weak credentials are rejected before establishing a secure session.

* **Tests**
  * Expanded coverage for protocol negotiation, authentication failures, and secure-session behavior.
  * Improved end-to-end test isolation for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->