### PR TITLE
fix: reject unassigned/reserved binary type codes per WIRE-1 §4.2

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -58,6 +58,21 @@ All fields are packed MSB-first. The bitstring is left-padded with `0` bits to r
 | 11 | THIRDPRTY |
 | 12 | BINARY |
 
+Codes 13-31 are **unassigned**. Per HIVEMIND-WIRE-1 §4.2 a receiver
+**MUST** reject a frame carrying an unassigned message-type code as
+malformed: `decode_bitstring()` raises `ValueError` for any code not in
+this map instead of silently coercing it to a type. The three client
+receive loops (`client.py`, `async_client.py`, `http_client.py`) catch
+that error, log it, and drop the frame rather than crashing.
+
+> **Spec-vs-impl note.** This numbering is the wire reality retained for
+> compatibility with deployed encoders and the HiveMind-js peer; it does
+> **not** match the aspirational table in HIVEMIND-WIRE-1 §4.2 (which
+> lists 6=INTERCOM, 7=PING, 8/11=reserved, 9=HELLO, 10=THIRDPRTY and
+> makes QUERY/CASCADE/RENDEZVOUS text-only wrapper types). Reconciling
+> the two is a wire-breaking change reserved for a coordinated spec
+> revision; only the unassigned-code rejection (13-31) is enforced here.
+
 ### Binary Payload Subtypes (`HiveMindBinaryPayloadType`, `message.py:32-41`)
 
 | Integer | Subtype | Description |

--- a/hivemind_bus_client/async_client.py
+++ b/hivemind_bus_client/async_client.py
@@ -431,7 +431,14 @@ class AsyncHiveMessageBusClient:
                 LOG.debug("Message was unencrypted")
 
         if isinstance(message, (bytes, bytearray)):
-            message = decode_bitstring(message)
+            try:
+                message = decode_bitstring(message)
+            except Exception:
+                # WIRE-1 §4.2: reject a malformed binary frame (e.g. an
+                # unassigned/reserved message-type code) instead of
+                # crashing the receive loop.
+                LOG.exception("dropping malformed binary frame")
+                return
         elif isinstance(message, str):
             message = json.loads(message)
         if isinstance(message, dict) and "ciphertext" in message:

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -352,7 +352,14 @@ class HiveMessageBusClient(OVOSBusClient):
                 LOG.debug("Message was unencrypted")
 
         if isinstance(message, bytes):
-            message = decode_bitstring(message)
+            try:
+                message = decode_bitstring(message)
+            except Exception:
+                # WIRE-1 §4.2: a malformed binary frame (e.g. an
+                # unassigned/reserved message-type code) MUST be rejected.
+                # Drop it instead of crashing the receive loop.
+                LOG.exception("dropping malformed binary frame")
+                return
         elif isinstance(message, str):
             message = json.loads(message)
         if isinstance(message, dict) and "ciphertext" in message:

--- a/hivemind_bus_client/http_client.py
+++ b/hivemind_bus_client/http_client.py
@@ -160,7 +160,14 @@ class HiveMindHTTPClient(threading.Thread):
                 LOG.debug("Message was unencrypted")
 
         if isinstance(message, bytes):
-            message = decode_bitstring(message)
+            try:
+                message = decode_bitstring(message)
+            except Exception:
+                # WIRE-1 §4.2: reject a malformed binary frame (e.g. an
+                # unassigned/reserved message-type code) instead of
+                # crashing the receive loop.
+                LOG.exception("dropping malformed binary frame")
+                return
         elif isinstance(message, str):
             message = json.loads(message)
         if isinstance(message, dict) and "ciphertext" in message:

--- a/hivemind_bus_client/serialization.py
+++ b/hivemind_bus_client/serialization.py
@@ -13,6 +13,24 @@ PROTOCOL_VERSION = 1  # integer, a version increase signals new functionality ad
                       # version 0 is the original hivemind protocol, 1 supports handshake + binary
 
 
+# WIRE-1 §4.2 registry-history note (spec-vs-impl divergence):
+# The 5-bit codes below are the codes that deployed HiveMind encoders
+# (this library and the HiveMind-js peer, see tests/../HiveMind-js
+# vectors.json) actually emit on the wire. They are retained EXACTLY as
+# assigned for wire compatibility with those decoders. This numbering
+# does NOT match the aspirational table in HIVEMIND-WIRE-1 §4.2 (which
+# lists 6=INTERCOM, 7=PING, 8=reserved, 9=HELLO, 10=THIRDPRTY,
+# 11=reserved, and makes QUERY/CASCADE/RENDEZVOUS text-only wrapper
+# types). Reconciling the two — renumbering the wire and moving the
+# wrapper types to text-only — is a wire-breaking change that belongs to
+# a coordinated spec revision, NOT to this bugfix. Changing any code
+# here would break interop with every deployed peer.
+#
+# What this fix DOES enforce from §4.2: a receiver MUST reject a frame
+# carrying an unassigned/reserved 5-bit code as malformed. Every code in
+# this map is currently assigned and round-trips; codes not in this map
+# (13-31) are unassigned and are rejected by _decode_bitstring_v1
+# instead of being silently coerced to THIRDPRTY (the fixed bug).
 _INT2TYPE = {0: HiveMessageType.HANDSHAKE,
              1: HiveMessageType.BUS,
              2: HiveMessageType.SHARED_BUS,
@@ -100,7 +118,18 @@ def decode_bitstring(bitstr):
 def _decode_bitstring_v1(s):
     binmap = {e: e.value for e in HiveMindBinaryPayloadType}
 
-    hive_type = _INT2TYPE.get(s.read(5).uint, 11)
+    type_code = s.read(5).uint
+    if type_code not in _INT2TYPE:
+        # WIRE-1 §4.2: "A receiver MUST reject a frame carrying an
+        # unassigned or reserved value as malformed." Previously any
+        # unknown code was silently coerced to 11 (THIRDPRTY), which
+        # masked corrupt/forged frames. Codes 13-31 are unassigned.
+        raise ValueError(
+            f"malformed binary frame: unassigned WIRE-1 message-type "
+            f"code {type_code} (assigned codes: "
+            f"{sorted(_INT2TYPE)})"
+        )
+    hive_type = _INT2TYPE[type_code]
     compressed = s.read(1).bool  # note: bool(BitStream) checks length (always True), .bool reads the actual bit
 
     metalen = s.read(8).uint * 8

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -243,6 +243,56 @@ class TestDecodeBitstringRegressions(unittest.TestCase):
         self.assertEqual(decoded.payload.msg_type, "speak")
 
 
+class TestUnassignedTypeCodeRejection(unittest.TestCase):
+    """WIRE-1 §4.2: a receiver MUST reject a frame carrying an unassigned
+    or reserved 5-bit message-type code as malformed, instead of silently
+    coercing it (the old behaviour defaulted every unknown code to 11 /
+    THIRDPRTY)."""
+
+    def _frame_with_type_code(self, type_code):
+        """Craft a minimal unversioned frame carrying an arbitrary 5-bit
+        message-type code and an empty (uncompressed) metadata block."""
+        s = BitArray()
+        s.append('uint:1=1')                 # start marker
+        s.append('uint:1=0')                 # versioned=False
+        s.append(f'uint:5={type_code}')      # message type
+        s.append('uint:1=0')                 # compression flag=0
+        s.append('uint:8=0')                 # metadata length = 0 bytes
+        # empty JSON object as the (uncompressed) metadata payload region
+        # is not needed: metalen=0, so the rest is payload; leave empty.
+        while len(s) % 8 != 0:
+            s.insert('uint:1=0', 0)
+        return s.bytes
+
+    def test_unassigned_codes_are_rejected(self):
+        # 13-31 are unassigned in the wire registry; the type-code gate
+        # runs before any metadata/payload parsing, so this raises the
+        # unassigned-code ValueError specifically.
+        for code in (13, 20, 31):
+            with self.subTest(code=code):
+                raw = self._frame_with_type_code(code)
+                with self.assertRaises(ValueError) as ctx:
+                    decode_bitstring(raw)
+                self.assertIn("unassigned", str(ctx.exception))
+
+    def test_all_assigned_types_roundtrip(self):
+        """Every payload-bearing assigned type still round-trips (guards
+        against accidentally rejecting a legitimately-emitted code)."""
+        payload = {"type": "test", "data": {}, "context": {}}
+        assigned_non_binary = [
+            HiveMessageType.HANDSHAKE, HiveMessageType.BUS,
+            HiveMessageType.SHARED_BUS, HiveMessageType.BROADCAST,
+            HiveMessageType.PROPAGATE, HiveMessageType.ESCALATE,
+            HiveMessageType.HELLO, HiveMessageType.QUERY,
+            HiveMessageType.CASCADE, HiveMessageType.PING,
+            HiveMessageType.RENDEZVOUS, HiveMessageType.THIRDPRTY,
+        ]
+        for mt in assigned_non_binary:
+            with self.subTest(msg_type=mt):
+                bs = get_bitstring(mt, payload=payload)
+                self.assertEqual(decode_bitstring(bs).msg_type, mt)
+
+
 class TestMycroft2Bitstring(unittest.TestCase):
     """Test mycroft2bitstring helper."""
 


### PR DESCRIPTION
## Problem

`_decode_bitstring_v1` decoded the 5-bit message-type code with
`_INT2TYPE.get(code, 11)` — **any** unknown or reserved code was
silently coerced to `11` (`THIRDPRTY`). This masks corrupt or forged
binary frames.

**HIVEMIND-WIRE-1 §4.2** (`architecture/hivemind-wire-1.md`):

> A receiver **MUST** map the 5-bit value back to its message type and
> **MUST** reject a frame carrying an unassigned or reserved value as
> malformed.

Surfaced by the hivemind-test-harness spec-MUST conformance suite.

## What changed

- `_decode_bitstring_v1` now raises `ValueError` for any 5-bit code not
  in the assigned registry (13–31 are unassigned). The type-code gate
  runs before metadata/payload parsing.
- The three client receive loops (`client.py`, `async_client.py`,
  `http_client.py`) wrap `decode_bitstring` and drop a malformed frame
  with a logged error, so a bad frame no longer crashes the receive
  loop mid-stream.
- Regression tests: unassigned codes (13/20/31) are rejected; every
  assigned payload-bearing type still round-trips.
- `docs/serialization.md` updated to document rejection + the divergence.

## Encoder investigation (why the fix is conservative)

The client binarizes **all** message types except `HELLO`/`HANDSHAKE`
(with `BINARY` special-cased) whenever the `binarize` flag is on
(`client.py:453-457`, `async_client.py:490-499`). So `QUERY` (7),
`CASCADE` (8), `RENDEZVOUS` (10) and `THIRDPRTY` (11) **are** legitimately
binary-emitted by this library today, and the HiveMind-js peer decodes
the same `_INT2TYPE` numbering (cross-platform `vectors.json`). Encoder
and decoder are self-consistent.

The library's wire numbering therefore diverges wholesale from the
aspirational §4.2 table:

| code | this library (wire reality) | §4.2 table |
|---|---|---|
| 6 | HELLO | INTERCOM |
| 7 | QUERY | PING |
| 8 | CASCADE | *reserved* |
| 9 | PING | HELLO |
| 10 | RENDEZVOUS | THIRDPRTY |
| 11 | THIRDPRTY | *reserved* |

Rejecting 8/11 or moving QUERY/CASCADE/RENDEZVOUS to text-only — as a
literal reading of §4.2 would require — **would break interop with every
deployed peer**. Per the "spec is prescriptive but never silently break
the wire" rule, that renumbering is left for a **coordinated spec
revision** (the spec's §4.2 registry-history clause already anticipates
this). It is documented inline in `serialization.py` and
`docs/serialization.md`.

## What this PR rejects vs still accepts

- **Rejects (new):** codes 13–31 (genuinely unassigned) → `ValueError`,
  frame dropped.
- **Still accepts:** codes 0–12 — all currently emitted and round-trip
  unchanged; no wire break.
- **Left for spec revision:** aligning the 6–11 numbering with §4.2,
  making the wrapper types text-only, and adding an `INTERCOM` code
  (absent from `_INT2TYPE`).

## Tests

`tests/test_serialization.py` — 35 passed, 4 skipped (cross-platform
vectors, HiveMind-js not checked out), 15 subtests passed. Client suites
green (60 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed or unsupported binary messages are now logged and discarded without interrupting message reception.
  - Unassigned message-type codes are correctly rejected instead of being interpreted as valid messages.

- **Documentation**
  - Clarified supported wire message-type codes and compatibility behavior.

- **Tests**
  - Added coverage confirming reserved codes are rejected and assigned message types continue to round-trip successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->