### PR TITLE
test: cover the XX-path pinned-key mismatch abort (CRYPTO-1 §3.4.5)

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -85,6 +85,87 @@ class TestConnectionState:
         assert proto.internal_protocol.node_id == ""
 
 
+class TestNoiseHandshakePinning:
+    """CRYPTO-1 §3.4.5 — a completed XX-path handshake against a static key
+    that contradicts a pinned key must abort; a matching or TOFU-absent pin
+    must not.
+    """
+
+    def _make_protocol_at_noise_msg2(self, remote_static_key: bytes,
+                                      handshake_finished: bool = True):
+        proto = _make_protocol()
+        proto.noise_handshake = MagicMock()
+        proto.noise_handshake.read_message.return_value = b""
+        proto.noise_handshake.handshake_finished = handshake_finished
+        proto._noise_pattern = "XXpsk2"
+        proto.hm.config.host = "hive.example"
+        proto.hm.config.port = 5678
+        message = HiveMessage(HiveMessageType.HANDSHAKE,
+                              {"noise": {"msg": (b"x" * 16).hex()}})
+        return proto, message
+
+    def test_pinned_key_contradicted_aborts_session(self):
+        """The XX-path guard: a static key that differs from the pin is a
+        possible MITM and must be rejected, not silently accepted.
+        """
+        remote_key = b"r" * 32
+        proto, message = self._make_protocol_at_noise_msg2(remote_key)
+        proto.identity.get_pinned_noise_key.return_value = b"p" * 32
+
+        with patch("hivemind_bus_client.protocol.NoiseTransport") as transport_cls:
+            transport_cls.return_value.remote_static_key = remote_key
+            with patch("hivemind_bus_client.protocol.LOG.error") as error:
+                proto.receive_noise_handshake(message)
+
+        assert proto.hm.noise_transport is None
+        proto.hm.handshake_event.set.assert_not_called()
+        proto.hm.close.assert_called_once()
+        proto.identity.pin_noise_key.assert_not_called()
+        assert any("pin" in call.args[0].lower() and "mismatch" in call.args[0].lower()
+                   for call in error.call_args_list)
+
+    def test_pinned_key_matches_completes_handshake(self):
+        """A pin that matches the negotiated static key is the expected,
+        non-fatal case: the session must be established normally.
+        """
+        remote_key = b"p" * 32
+        proto, message = self._make_protocol_at_noise_msg2(remote_key)
+        proto.identity.get_pinned_noise_key.return_value = remote_key
+        proto.identity.public_key = "pub"
+        proto.hm.session_id = "test-session"
+        proto.site_id = "living-room"
+
+        with patch("hivemind_bus_client.protocol.NoiseTransport") as transport_cls:
+            transport_cls.return_value.remote_static_key = remote_key
+            proto.receive_noise_handshake(message)
+
+        assert proto.hm.noise_transport is transport_cls.return_value
+        proto.hm.handshake_event.set.assert_called_once()
+        proto.hm.close.assert_not_called()
+        proto.identity.pin_noise_key.assert_not_called()
+
+    def test_no_pin_tofu_pins_new_key(self):
+        """First-connection TOFU: no prior pin means the negotiated static
+        key is trusted and stored for future comparisons.
+        """
+        remote_key = b"n" * 32
+        proto, message = self._make_protocol_at_noise_msg2(remote_key)
+        proto.identity.get_pinned_noise_key.return_value = None
+        proto.identity.public_key = "pub"
+        proto.hm.session_id = "test-session"
+        proto.site_id = "living-room"
+
+        with patch("hivemind_bus_client.protocol.NoiseTransport") as transport_cls:
+            transport_cls.return_value.remote_static_key = remote_key
+            proto.receive_noise_handshake(message)
+
+        assert proto.hm.noise_transport is transport_cls.return_value
+        proto.hm.handshake_event.set.assert_called_once()
+        proto.hm.close.assert_not_called()
+        proto.identity.pin_noise_key.assert_called_once_with(
+            proto._noise_pin_id, remote_key)
+
+
 class TestHandlePing:
     def test_sends_responsive_ping(self):
         proto = _make_protocol()


### PR DESCRIPTION
## Coverage gap

CRYPTO-1 §3.4.5 requires: "a peer whose handshake completes against a static key that contradicts a pinned key MUST abort." The client implements this in `hivemind_bus_client/protocol.py`, `HiveMindSlaveProtocol.receive_noise_handshake` (the `pinned and transport.remote_static_key != pinned` branch that calls `_abort_noise("pinned key mismatch")`).

No test anywhere in the suite exercised this branch. In practice a pinned client selects the `KKpsk0` pattern via `select_noise_options`, so a static-key mismatch fails earlier, cryptographically, inside the handshake itself (already covered by `tests/test_noise.py::test_wrong_password_aborts` and friends). The XX-path mismatch check in `receive_noise_handshake` is therefore currently unreachable through normal negotiation — but it is the guard that fires if a server ever offers only `XXpsk2` to a previously-pinned client (e.g. after a server DB reset that regenerates its static key while the client's pin store still holds the old one). Without a test, a future refactor of `receive_noise_handshake` could silently drop or invert this check and nothing would notice.

## What this PR adds

`tests/test_protocol.py::TestNoiseHandshakePinning`, driving `receive_noise_handshake` directly with a mocked completed `NoiseTransport`:

- `test_pinned_key_contradicted_aborts_session` — pinned key differs from the negotiated static key: asserts `hm.noise_transport` stays `None`, `hm.handshake_event.set()` is never called, `hm.close()` is called (the observable effects of `_abort_noise`), and an error is logged naming the pin mismatch.
- `test_pinned_key_matches_completes_handshake` — pinned key matches: asserts the session completes normally (`noise_transport` set, `handshake_event.set()` called, no abort).
- `test_no_pin_tofu_pins_new_key` — no prior pin (TOFU): asserts the key is trusted and stored via `identity.pin_noise_key`. This case was not previously covered either, so it's included alongside the mismatch/match pair.

All three pass against current `dev` (post-#141/#142). Full unit suite: 372 passed, 4 skipped (up from 369/4 on `dev` tip), 0 regressions.

## AI transparency

Tests implemented by Claude Sonnet under Claude Opus 4.8 orchestration.