### PR TITLE
docs: correct stale API, CLI, and identity claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@ HiveMind satellites are differentiated by how much audio and language processing
 
 Every satellite in that table uses `HiveMessageBusClient` from this library to open the connection, complete the handshake, and exchange `HiveMessage` packets with the hub. The hub's `hivemind-audio-binary-protocol` plugin provides server-side STT and TTS. The satellite cannot choose the engine. The hub operator configures it.
 
-See the [whitepaper](https://github.com/JarbasHiveMind/HiveMind-core/blob/dev/docs/whitepaper.md) for protocol details.
+See the [hivemind-core protocol docs](https://github.com/JarbasHiveMind/HiveMind-core/blob/dev/docs/protocol.md) for protocol details.
 
 ## Hardware and OS requirements
 
-- Python 3.9 or later
+- Python 3.10 or later
 - No special hardware. It runs on any machine with network access to the hub.
-- The async client (`hivemind-bus-client[async]`) requires Python 3.10+
 
 ## Install
 
@@ -57,6 +56,17 @@ hivemind-core add-client --name "my-satellite" --access-key KEY --password PASS
 ```
 
 `add-client` prints an access key and a password. Keep both. You need them on every satellite you pair.
+
+A new client starts with an **empty** message-type whitelist, so the hub denies everything
+it sends. Grant the types the satellite needs, using the node id that `add-client` printed:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:utterance" 1
+hivemind-core allow-msg "speak" 1
+```
+
+Skip this and the satellite connects, but every utterance comes back as
+`hive.policy.denied`.
 
 ### 2. Configure the satellite
 
@@ -142,6 +152,11 @@ client.connect()                # blocks until the handshake completes
 
 `connect()` runs the WebSocket in a background thread and calls `wait_for_handshake()`. After it returns the connection is live.
 
+The client owns its own reconnect loop. If the socket closes, a single worker thread
+reopens it and repeats the handshake. `wait_for_handshake()` waits through reconnects
+forever by default. Pass `handshake_max_retries` to `connect()` to make a bad password
+fail fast instead of blocking.
+
 Ping settings can also be supplied with environment variables. Client-specific
 variables (`HIVEMIND_WEBSOCKET_CLIENT_PING_INTERVAL`,
 `HIVEMIND_WEBSOCKET_CLIENT_PING_TIMEOUT`) win over shared hub defaults
@@ -226,7 +241,7 @@ client.emit(HiveMessage(
 
 ### Peer-to-peer encrypted messages (INTERCOM)
 
-INTERCOM uses hybrid encryption (random AES-256-GCM key per message, RSA-encrypted key exchange):
+INTERCOM uses hybrid encryption (random AES-256-GCM key per message, RSA-encrypted key exchange). It has no binary wire code, so the client always sends it as a text frame:
 
 ```python
 target_pubkey = "-----BEGIN PUBLIC KEY-----\n..."
@@ -282,6 +297,10 @@ client.connect()
 | `INTERCOM` | any → any | End-to-end hybrid-encrypted (AES-GCM + RSA) |
 | `PING` | inside PROPAGATE | Flood-based network topology discovery |
 | `BINARY` | hub → satellite | Raw binary payload (TTS audio, file transfer) |
+| `THIRDPRTY` | any → any | User-land payload. HiveMind relays it and does nothing else |
+
+`emit()` raises `ValueError` for a message type that has no binary wire code. It never
+relabels the type to get the frame out.
 
 ## Security
 
@@ -325,6 +344,12 @@ hivemind-client send-mycroft \
 # Send as ESCALATE or PROPAGATE
 hivemind-client escalate --msg "recognizer_loop:utterance" --payload '{"utterances": ["hello"]}'
 hivemind-client propagate --msg "recognizer_loop:utterance" --payload '{"utterances": ["hello"]}'
+
+# Check that the saved identity can reach the hub
+hivemind-client test-identity
+
+# Generate a new RSA key pair for peer-to-peer messages
+hivemind-client reset-pgp
 ```
 
 ## Troubleshooting
@@ -335,7 +360,9 @@ hivemind-client propagate --msg "recognizer_loop:utterance" --payload '{"utteran
 
 **`got encrypted message, but could not decrypt!`**: The access key or password does not match what was registered on the hub. Re-run `hivemind-core add-client` and update the satellite identity.
 
-**Connection drops immediately**: The hub may have rejected the access key (wrong key, revoked key, or blacklisted key). Check hub logs: `journalctl -u hivemind-core -f`.
+**Connection drops immediately**: The hub rejected the access key, or the protocol version the client offered is below the hub's `min_protocol_version`. Check hub logs: `journalctl -u hivemind-core -f`.
+
+**Every message comes back as `hive.policy.denied`**: The message type is not in this client's whitelist on the hub. Run `hivemind-core allow-msg <msg_type> <node_id>`. An empty whitelist also denies binary payloads.
 
 ## Documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-## `HiveMessage` (`hivemind_bus_client/message.py:45`)
+## `HiveMessage` (`hivemind_bus_client/message.py`)
 
 The fundamental message type exchanged across the HiveMind network.
 
@@ -8,25 +8,25 @@ The fundamental message type exchanged across the HiveMind network.
 
 | Property | Type | Description | Source |
 |---|---|---|---|
-| `msg_type` | `str` | One of the `HiveMessageType` values | `message.py:105` |
-| `payload` | `Message \| HiveMessage \| dict \| bytes` | Message content, automatically cast to the appropriate type | `message.py:128` |
-| `bin_type` | `HiveMindBinaryPayloadType` | Binary payload subtype (only for `BINARY` messages) | `message.py:164` |
-| `metadata` | `dict` | Auxiliary metadata (e.g. `sample_rate`, `lang`, `file_name`) | `message.py:94` |
-| `node_id` | `str` | Node semi-unique identifier | `message.py:109` |
-| `source_peer` | `str` | Peer ID of the sender | `message.py:114` |
-| `target_peers` | `list[str]` | Intended recipients | `message.py:118` |
-| `target_site_id` | `str` | Route to a specific site ID | `message.py:98` |
-| `target_public_key` | `str` | Route to a specific RSA public key (used with INTERCOM) | `message.py:102` |
-| `route` | `list[dict]` | Hop history | `message.py:123` |
+| `msg_type` | `str` | One of the `HiveMessageType` values | `message.py` |
+| `payload` | `Message \| HiveMessage \| dict \| bytes` | Message content, automatically cast to the appropriate type | `message.py` |
+| `bin_type` | `HiveMindBinaryPayloadType` | Binary payload subtype (only for `BINARY` messages) | `message.py` |
+| `metadata` | `dict` | Auxiliary metadata (e.g. `sample_rate`, `lang`, `file_name`) | `message.py` |
+| `node_id` | `str` | Node semi-unique identifier | `message.py` |
+| `source_peer` | `str` | Peer ID of the sender | `message.py` |
+| `target_peers` | `list[str]` | Intended recipients | `message.py` |
+| `target_site_id` | `str` | Route to a specific site ID | `message.py` |
+| `target_public_key` | `str` | Route to a specific RSA public key (used with INTERCOM) | `message.py` |
+| `route` | `list[dict]` | Hop history | `message.py` |
 
 ### Serialization
 
-- `serialize()` (`message.py:200`): Returns the JSON string representation of the message.
-- `deserialize(payload)` (`message.py:204`): Reconstructs a `HiveMessage` from a JSON string or dictionary.
+- `serialize()` (`message.py`): Returns the JSON string representation of the message.
+- `deserialize(payload)` (`message.py`): Reconstructs a `HiveMessage` from a JSON string or dictionary.
 
 ---
 
-## `HiveMessageType` (`hivemind_bus_client/message.py:9`)
+## `HiveMessageType` (`hivemind_bus_client/message.py`)
 
 Enumeration of HiveMind message types.
 
@@ -49,7 +49,7 @@ Enumeration of HiveMind message types.
 
 ---
 
-## `HiveMindBinaryPayloadType` (`hivemind_bus_client/message.py:33`)
+## `HiveMindBinaryPayloadType` (`hivemind_bus_client/message.py`)
 
 Describes the content of a `BINARY` message.
 
@@ -65,75 +65,75 @@ Describes the content of a `BINARY` message.
 
 ---
 
-## `HiveMessageBusClient` (`hivemind_bus_client/client.py:93`)
+## `HiveMessageBusClient` (`hivemind_bus_client/client.py`)
 
 WebSocket client that extends `ovos_bus_client.MessageBusClient`.
 
 ### Core Methods
 
-- `connect(bus=FakeBus(), protocol=None, site_id=None)` (`client.py:193`): Connects to the HiveMind hub, starts the background thread, and waits for the handshake to complete.
-- `emit(message, binary_type=UNDEFINED)` (`client.py:348`): Sends a `HiveMessage` or `MycroftMessage`. It automatically injects routing context for `BUS` messages (`client.py:379`).
-- `on(event_name, func)` (`client.py:434`): Registers a handler. It automatically detects if the event name is a `HiveMessageType` or a standard OVOS message type (`client.py:435`).
-- `on_mycroft(mycroft_msg_type, func)` (`client.py:429`): Explicitly registers a handler for an OVOS internal bus message.
-- `remove(event_name, func)` (`client.py:447`): Removes a registered handler.
-- `wait_for_handshake(timeout=5, max_retries=None)` (`client.py:236`): Blocks until the cryptographic handshake with the hub is finished. By default it waits through reconnects forever. Pass `max_retries` for a hard timeout.
-- `emit_intercom(message, pubkey)` (`client.py:538`): Sends a hybrid-encrypted (AES-GCM + RSA) message targeted at a specific node's public key.
+- `connect(bus=FakeBus(), protocol=None, site_id=None, handshake_max_retries=None)` (`client.py`): Connects to the HiveMind hub, starts the background thread, and waits for the handshake to complete.
+- `emit(message, binary_type=UNDEFINED)` (`client.py`): Sends a `HiveMessage` or `MycroftMessage`. It automatically injects routing context for `BUS` messages (`client.py`).
+- `on(event_name, func)` (`client.py`): Registers a handler. It automatically detects if the event name is a `HiveMessageType` or a standard OVOS message type (`client.py`).
+- `on_mycroft(mycroft_msg_type, func)` (`client.py`): Explicitly registers a handler for an OVOS internal bus message.
+- `remove(event_name, func)` (`client.py`): Removes a registered handler.
+- `wait_for_handshake(timeout=5, max_retries=None)` (`client.py`): Blocks until the cryptographic handshake with the hub is finished. By default it waits through reconnects forever. Pass `max_retries` for a hard timeout.
+- `emit_intercom(message, pubkey)` (`client.py`): Sends a hybrid-encrypted (AES-GCM + RSA) message targeted at a specific node's public key.
 
 ### Waiting for Messages
 
-- `wait_for_message(message_type, timeout=3.0)` (`client.py:454`): Blocks until a specific `HiveMessageType` is received.
-- `wait_for_payload(payload_type, message_type=THIRDPRTY, timeout=3.0)` (`client.py:467`): Blocks until a message of a specific type with a specific payload type is received.
-- `wait_for_mycroft(mycroft_msg_type, timeout=3.0)` (`client.py:484`): Blocks until a specific OVOS message is received over the `BUS` message type.
-- `wait_for_response(message, reply_type=None, timeout=3.0)` (`client.py:488`): Sends a message and waits for a response.
-- `wait_for_payload_response(message, payload_type, reply_type=None, timeout=3.0)` (`client.py:511`): Sends a message and waits for a specific payload in the response.
+- `wait_for_message(message_type, timeout=3.0)` (`client.py`): Blocks until a specific `HiveMessageType` is received.
+- `wait_for_payload(payload_type, message_type=THIRDPRTY, timeout=3.0)` (`client.py`): Blocks until a message of a specific type with a specific payload type is received.
+- `wait_for_mycroft(mycroft_msg_type, timeout=3.0)` (`client.py`): Blocks until a specific OVOS message is received over the `BUS` message type.
+- `wait_for_response(message, reply_type=None, timeout=3.0)` (`client.py`): Sends a message and waits for a response.
+- `wait_for_payload_response(message, payload_type, reply_type=None, timeout=3.0)` (`client.py`): Sends a message and waits for a specific payload in the response.
 
 ---
 
-## `BinaryDataCallbacks` (`hivemind_bus_client/client.py:26`)
+## `BinaryDataCallbacks` (`hivemind_bus_client/client.py`)
 
 Base class for handling incoming binary data.
 
-- `handle_receive_tts(bin_data, utterance, lang, file_name)` (`client.py:27`): Called when TTS audio is received.
-- `handle_receive_file(bin_data, file_name)` (`client.py:33`): Called when a file is received.
+- `handle_receive_tts(bin_data, utterance, lang, file_name)` (`client.py`): Called when TTS audio is received.
+- `handle_receive_file(bin_data, file_name)` (`client.py`): Called when a file is received.
 
 ---
 
-## `NodeIdentity` (`hivemind_bus_client/identity.py:7`)
+## `NodeIdentity` (`hivemind_bus_client/identity.py`)
 
 Manages the node's identity, including credentials and RSA keys.
 
 ### Persistence
 
-- `save()` (`identity.py:219`): Persists identity settings to disk.
-- `reload()` (`identity.py:225`): Reloads settings from the identity file.
-- `create_keys()` (`identity.py:231`): Generates a new RSA key pair.
+- `save()` (`identity.py`): Persists identity settings to disk.
+- `reload()` (`identity.py`): Reloads settings from the identity file.
+- `create_keys()` (`identity.py`): Generates a new RSA key pair.
 
 ### Trusted Keys
 
 Trusted keys are stored as an alias → public key mapping in the identity file. Used by protocol handlers to gate BUS injection from PROPAGATE and INTERCOM messages.
 
-- `trusted_keys` (`identity.py:153`): `Dict[str, str]`, an alias-to-public-key mapping.
-- `add_trusted_key(alias, pubkey)` (`identity.py:176`): Add a peer. Returns `False` if alias already exists.
-- `remove_trusted_key(alias)` (`identity.py:195`): Remove by alias. Returns `False` if not found.
-- `is_trusted_key(pubkey)` (`identity.py:210`): Check if a public key is trusted.
-- `get_trusted_alias(pubkey)` (`identity.py:222`): Look up alias for a public key. Returns `None` if not found.
+- `trusted_keys` (`identity.py`): `Dict[str, str]`, an alias-to-public-key mapping.
+- `add_trusted_key(alias, pubkey)` (`identity.py`): Add a peer. Returns `False` if alias already exists.
+- `remove_trusted_key(alias)` (`identity.py`): Remove by alias. Returns `False` if not found.
+- `is_trusted_key(pubkey)` (`identity.py`): Check if a public key is trusted.
+- `get_trusted_alias(pubkey)` (`identity.py`): Look up alias for a public key. Returns `None` if not found.
 
 ---
 
-## `HiveMapper` (`hivemind_bus_client/hive_map.py:38`)
+## `HiveMapper` (`hivemind_bus_client/hive_map.py`)
 
 Collects responsive PINGs from a flood and builds a directed hive topology graph.
 
 ### Key Methods
 
-- `on_ping(message, received_at=None)` (`hive_map.py:66`): Ingest a PING and update topology.
-- `check_flood_id(flood_id, max_size=1000)` (`hive_map.py:119`): Flood-loop prevention with FIFO eviction.
-- `mark_trusted_nodes(trusted_keys)` (`hive_map.py:145`): Set `NodeInfo.trusted` based on `NodeIdentity.trusted_keys`.
-- `is_peer_trusted(peer)` (`hive_map.py:158`): Check if a discovered peer is trusted.
-- `to_ascii(root_peer=None)` (`hive_map.py:173`): Render topology as ASCII tree.
-- `to_dict()` / `to_json()` (`hive_map.py:147`): JSON-serialisable topology snapshot.
+- `on_ping(message, received_at=None)` (`hive_map.py`): Ingest a PING and update topology.
+- `check_flood_id(flood_id, max_size=1000)` (`hive_map.py`): Flood-loop prevention with FIFO eviction.
+- `mark_trusted_nodes(trusted_keys)` (`hive_map.py`): Set `NodeInfo.trusted` based on `NodeIdentity.trusted_keys`.
+- `is_peer_trusted(peer)` (`hive_map.py`): Check if a discovered peer is trusted.
+- `to_ascii(root_peer=None)` (`hive_map.py`): Render topology as ASCII tree.
+- `to_dict()` / `to_json()` (`hive_map.py`): JSON-serialisable topology snapshot.
 
-### `NodeInfo` (`hive_map.py:15`)
+### `NodeInfo` (`hive_map.py`)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -153,15 +153,15 @@ Convenience decorators for registering handlers on specific message types.
 
 | Decorator | Message Type | Source |
 |-----------|-------------|--------|
-| `on_query(payload_type, bus)` | `QUERY` | `decorators.py:236` |
-| `on_cascade(payload_type, bus)` | `CASCADE` | `decorators.py:253` |
-| `on_propagate(payload_type, bus)` | `PROPAGATE` | `decorators.py:164` |
-| `on_broadcast(payload_type, bus)` | `BROADCAST` | `decorators.py:128` |
-| `on_escalate(payload_type, bus)` | `ESCALATE` | `decorators.py:182` |
-| `on_ping(payload_type, bus)` | `PING` | `decorators.py:146` |
-| `on_mycroft_message(payload_type, bus)` | `BUS` | `decorators.py:92` |
-| `on_shared_bus(payload_type, bus)` | `SHARED_BUS` | `decorators.py:110` |
-| `on_hive_message(message_type, bus)` | any | `decorators.py:78` |
+| `on_query(payload_type, bus)` | `QUERY` | `decorators.py` |
+| `on_cascade(payload_type, bus)` | `CASCADE` | `decorators.py` |
+| `on_propagate(payload_type, bus)` | `PROPAGATE` | `decorators.py` |
+| `on_broadcast(payload_type, bus)` | `BROADCAST` | `decorators.py` |
+| `on_escalate(payload_type, bus)` | `ESCALATE` | `decorators.py` |
+| `on_ping(payload_type, bus)` | `PING` | `decorators.py` |
+| `on_mycroft_message(payload_type, bus)` | `BUS` | `decorators.py` |
+| `on_shared_bus(payload_type, bus)` | `SHARED_BUS` | `decorators.py` |
+| `on_hive_message(message_type, bus)` | any | `decorators.py` |
 
 ---
 
@@ -169,8 +169,8 @@ Convenience decorators for registering handlers on specific message types.
 
 ### Hybrid Encryption (INTERCOM)
 
-- `hybrid_encrypt(public_key, plaintext, sign_key=None)` (`encryption.py:502`): AES-256-GCM payload + RSA-encrypted ephemeral key. Returns a JSON-serialisable dict.
-- `hybrid_decrypt(private_key, envelope)` (`encryption.py:547`): Decrypts a hybrid-encrypted envelope.
+- `hybrid_encrypt(public_key, plaintext, sign_key=None)` (`encryption.py`): AES-256-GCM payload + RSA-encrypted ephemeral key. Returns a JSON-serialisable dict.
+- `hybrid_decrypt(private_key, envelope)` (`encryption.py`): Decrypts a hybrid-encrypted envelope.
 
 ### Symmetric Encryption (per-link)
 
@@ -179,7 +179,7 @@ Convenience decorators for registering handlers on specific message types.
 
 ---
 
-## `HiveMessageWaiter` / `HivePayloadWaiter` (`hivemind_bus_client/client.py:38`, `78`)
+## `HiveMessageWaiter` / `HivePayloadWaiter` (`hivemind_bus_client/client.py`)
 
 Utility classes used for one-shot message waiting. These are used internally by the `wait_for_*` methods of `HiveMessageBusClient`.
 

--- a/docs/binary_handlers.md
+++ b/docs/binary_handlers.md
@@ -37,8 +37,8 @@ client.connect()
 
 ## Available Callback Methods
 
-- **`handle_receive_tts`**: Called when the AI generates audio from text (`client.py:27`).
-- **`handle_receive_file`**: Called for generic file transfers (`client.py:33`).
+- **`handle_receive_tts`**: Called when the AI generates audio from text (`client.py`).
+- **`handle_receive_file`**: Called for generic file transfers (`client.py`).
 
 ---
 [← Binary Serialization](serialization.md) · [Home](index.md) · [Identity & Credentials →](identity.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,8 @@ hivemind-client set-identity [OPTIONS]
 |---|---|
 | `--key TEXT` | HiveMind access key |
 | `--password TEXT` | HiveMind password |
+| `--host TEXT` | Default hub URL, `ws://` or `wss://` |
+| `--port INTEGER` | Default hub port |
 | `--siteid TEXT` | Location identifier injected into `message.context` |
 
 **Example:**
@@ -44,8 +46,10 @@ hivemind-client terminal [OPTIONS]
 | Option | Description |
 |---|---|
 | `--key TEXT` | HiveMind access key (overrides identity file) |
+| `--password TEXT` | HiveMind password (overrides identity file) |
 | `--host TEXT` | HiveMind host URL |
-| `--port INTEGER` | HiveMind port |
+| `--port INTEGER` | HiveMind port (default 5678) |
+| `--siteid TEXT` | Location identifier (overrides identity file) |
 
 **Example:**
 
@@ -68,10 +72,15 @@ hivemind-client send-mycroft [OPTIONS]
 | Option | Description |
 |---|---|
 | `--key TEXT` | HiveMind access key |
+| `--password TEXT` | HiveMind password |
 | `--host TEXT` | HiveMind host |
-| `--port INTEGER` | HiveMind port |
+| `--port INTEGER` | HiveMind port (default 5678) |
+| `--siteid TEXT` | Location identifier |
 | `--msg TEXT` | OVOS message type to inject |
 | `--payload TEXT` | OVOS message data as a JSON string |
+
+The hub must have the message type in this client's whitelist. If it does not, the hub
+answers `hive.policy.denied`. Grant it with `hivemind-core allow-msg <msg_type> <node_id>`.
 
 **Example:**
 
@@ -85,7 +94,7 @@ hivemind-client send-mycroft \
 
 ## `escalate`
 
-Send a single OVOS message wrapped in a `HiveMessageType.ESCALATE` envelope. The message is forwarded upstream through the hub hierarchy. It takes the same `--key`, `--host`, `--port`, `--msg`, and `--payload` options as `send-mycroft`.
+Send a single OVOS message wrapped in a `HiveMessageType.ESCALATE` envelope. The message is forwarded upstream through the hub hierarchy. It takes the same options as `send-mycroft`.
 
 ```bash
 hivemind-client escalate [OPTIONS]
@@ -95,10 +104,53 @@ hivemind-client escalate [OPTIONS]
 
 ## `propagate`
 
-Send a single OVOS message wrapped in a `HiveMessageType.PROPAGATE` envelope. The message is forwarded to all peers and upstream hubs. It takes the same `--key`, `--host`, `--port`, `--msg`, and `--payload` options as `send-mycroft`.
+Send a single OVOS message wrapped in a `HiveMessageType.PROPAGATE` envelope. The message is forwarded to all peers and upstream hubs. It takes the same options as `send-mycroft`.
 
 ```bash
 hivemind-client propagate [OPTIONS]
+```
+
+---
+
+## `ping`
+
+Send a PING flood and print the reachable hive topology as an ASCII tree.
+
+```bash
+hivemind-client ping [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--key TEXT` | HiveMind access key |
+| `--password TEXT` | HiveMind password |
+| `--host TEXT` | HiveMind host |
+| `--port INTEGER` | HiveMind port (default 5678) |
+| `--siteid TEXT` | Location identifier |
+| `--timeout FLOAT` | Seconds to collect answering PINGs (default 5.0) |
+| `--json` | Print the raw JSON topology instead of the tree |
+
+See the [CLI Guide](cli_guide.md) for sample output.
+
+---
+
+## `test-identity`
+
+Open a connection with the saved identity and report whether the handshake completes.
+
+```bash
+hivemind-client test-identity
+```
+
+---
+
+## `reset-pgp`
+
+Generate a new RSA key pair for this node. Peers that trust the old public key must be
+updated.
+
+```bash
+hivemind-client reset-pgp
 ```
 
 ---

--- a/docs/cli_guide.md
+++ b/docs/cli_guide.md
@@ -10,14 +10,14 @@ Before connecting, you must set your client credentials. This is handled by `hiv
 hivemind-client set-identity --key "MY_ACCESS_KEY" --password "MY_PASSWORD"
 ```
 - **Source**: `hivemind_bus_client.scripts.set_identity`
-- **Storage**: `~/.config/hivemind-core/identity.json` (managed by `NodeIdentity`).
+- **Storage**: `~/.config/hivemind/_identity.json` (managed by `NodeIdentity`).
 
 ## Terminal Interface
 
 The `terminal` command launches a simple interactive CLI where you can type utterances and see the AI's response. It uses a specialized `HiveMessageBusClient` instance.
 
 ```bash
-hivemind-client terminal --host "192.168.1.10" --port 5678
+hivemind-client terminal --host "ws://192.168.1.10" --port 5678
 ```
 - **Source**: `hivemind_bus_client.scripts.terminal`
 
@@ -33,7 +33,7 @@ hivemind-client send-mycroft --msg "speak" --payload '{"utterance": "Hello from 
 ## Propagation and Escalation
 
 - **`escalate`**: Send a message to a Master Mind (from a Slave Mind). Uses `HiveMessageType.ESCALATE`.
-- **`propagate`**: Broadcast a message to all child satellites (from a Mind/Slave Mind). Uses `HiveMessageType.PROPAGATE`.
+- **`propagate`**: Flood a message to every peer, downstream and upstream alike. Uses `HiveMessageType.PROPAGATE`.
 
 ```bash
 hivemind-client escalate --msg "recognizer_loop:utterance" --payload '{"utterances": ["help"]}'
@@ -71,20 +71,27 @@ Options:
 **Example output (ASCII tree):**
 
 ```
-[self] my-laptop::abc123  site=office
-├── living-room-hub::def456   site=living-room   rtt=12ms
-│   ├── kitchen-speaker::ghi  site=kitchen       rtt=34ms
-│   └── bedroom-sat::jkl      site=bedroom       rtt=28ms
-└── garage-pi::mno012          site=garage        rtt=67ms
+[self] my-laptop::abc123
+├── living-room-hub::def456   site=living-room  latency=12ms
+│   ├── kitchen-speaker::ghi  site=kitchen      latency=34ms
+│   └── bedroom-sat::jkl      site=bedroom      latency=28ms
+└── garage-pi::mno012         site=garage       latency=67ms
 ```
+
+`latency` is the receiver clock minus the sender clock, not a round trip. On nodes with
+unsynchronized clocks it can read negative.
 
 **Example output (JSON):**
 
 ```json
 {
   "nodes": [
-    { "peer": "living-room-hub::def456", "site_id": "living-room", "pong_timestamp": 1741478412.034 },
-    { "peer": "kitchen-speaker::ghi",    "site_id": "kitchen",      "pong_timestamp": 1741478412.056 }
+    { "peer": "living-room-hub::def456", "site_id": "living-room",
+      "timestamp": 1741478412.034, "latency_ms": 12.0,
+      "public_key": null, "lang": "en-us", "trusted": false },
+    { "peer": "kitchen-speaker::ghi", "site_id": "kitchen",
+      "timestamp": 1741478412.056, "latency_ms": 34.0,
+      "public_key": null, "lang": "en-us", "trusted": false }
   ],
   "edges": [
     { "source": "my-laptop::abc123",       "target": "living-room-hub::def456" },
@@ -98,7 +105,7 @@ Options:
 > to act as a discovery boundary and will simply not appear in the output.
 
 - **Source**: `hivemind_bus_client.scripts.ping`
-- **Backend**: `hivemind_core.hive_map.HiveMapper`
+- **Backend**: `hivemind_bus_client.hive_map.HiveMapper`
 
 ---
 [← CLI Reference](cli.md) · [Home](index.md) · [Examples →](examples.md)

--- a/docs/client_api.md
+++ b/docs/client_api.md
@@ -7,13 +7,13 @@ Use this for real-time, bidirectional communication over WebSockets.
 - **Source**: `hivemind_bus_client.client.HiveMessageBusClient`
 
 ### Basic Connection
-The client handles the encrypted handshake (via `poorman_handshake`) and transport layer security (AES-256-GCM via `hivemind_bus_client.encryption`).
+The client handles the encrypted handshake (via `poorman_handshake`) and the session cipher (AES-GCM or ChaCha20-Poly1305, via `hivemind_bus_client.encryption`).
 
 ```python
 from hivemind_bus_client.client import HiveMessageBusClient
 
-# Uses identity from ~/.config/hivemind-core/identity.json by default
-client = HiveMessageBusClient(host="192.168.1.10", port=5678)
+# Uses identity from ~/.config/hivemind/_identity.json by default
+client = HiveMessageBusClient(host="ws://192.168.1.10", port=5678)
 client.connect() # Executes poorman_handshake.PasswordHandShake
 ```
 
@@ -52,8 +52,18 @@ client.connect() # Performs the encrypted handshake via HTTP POST
 ```
 
 ## 3. Decorators
-The library includes useful decorators in `hivemind_bus_client.decorators` for wrapping functions as HiveMind services.
-- **`@with_hivemind`**: Automatically manages client connection and cleanup.
+`hivemind_bus_client.decorators` registers a function as a handler for one message type.
+Each decorator takes the payload type and the bus.
+
+```python
+from hivemind_bus_client.decorators import on_mycroft_message
+
+@on_mycroft_message("speak", bus=client)
+def on_speak(msg):
+    print(msg.data["utterance"])
+```
+
+See the [API Reference](api.md) for the full decorator list.
 
 ---
 [← API Reference](api.md) · [Home](index.md) · [Async Client →](async_client.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,6 +2,15 @@
 
 All examples assume credentials have been set up via `hivemind-client set-identity` or are passed directly to the constructor.
 
+They also assume the hub already granted this client the message types they send. A new
+client has an empty whitelist and the hub denies everything it sends, binary payloads
+included. Grant each type on the hub:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
+hivemind-core allow-msg "speak" <node_id>
+```
+
 ---
 
 ## Simple chat (WebSocket)

--- a/docs/fakebus.md
+++ b/docs/fakebus.md
@@ -64,9 +64,9 @@ asyncio.run(main())
 | WebSocket | None. `connect()` is a no-op that flips `connected_event` and `handshake_event`. |
 | Handshake | Skipped. `handshake_event` is set during `connect()`. |
 | Encryption / binary framing | Not exercised. `emit()` dispatches the message object directly through `pyee` rather than serializing it onto a wire. |
-| `HiveMessageType.BUS` routing-context injection | **Real**: `source`, `platform`, `destination`, and `session` are injected exactly as the real client does (`fakebus.py:175`), so session-aware downstream tests behave identically. |
-| Internal-bus dispatch (`on("speak", ...)`) | **Real**: attaches to a real `ovos_utils.fakebus.FakeBus` (`fakebus.py:130`), just like the real client. |
-| `emitted` list | Test affordance. Every `HiveMessage` passed to `emit()` is appended for assertions (`fakebus.py:189`). |
+| `HiveMessageType.BUS` routing-context injection | **Real**: `source`, `platform`, `destination`, and `session` are injected exactly as the real client does (`fakebus.py`), so session-aware downstream tests behave identically. |
+| Internal-bus dispatch (`on("speak", ...)`) | **Real**: attaches to a real `ovos_utils.fakebus.FakeBus` (`fakebus.py`), just like the real client. |
+| `emitted` list | Test affordance. Every `HiveMessage` passed to `emit()` is appended for assertions (`fakebus.py`). |
 
 ## API surface
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -41,7 +41,7 @@ identity.remove_trusted_key("living-room-hub")
 identity.save()
 ```
 
-Source: `NodeIdentity.trusted_keys`, `identity.py:153`
+Source: `NodeIdentity.trusted_keys`, `identity.py`
 
 ## Setting identity from the CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@
 
 ## Primary Components
 
-- **`HiveMessageBusClient`**: The main WebSocket client class (`hivemind_bus_client/client.py:93`).
-- **`HiveMessage`**: The fundamental message unit of the HiveMind protocol (`hivemind_bus_client/message.py:45`).
-- **`NodeIdentity`**: Manages device credentials, keys, and identity settings (`hivemind_bus_client/identity.py:7`).
+- **`HiveMessageBusClient`**: The main WebSocket client class (`hivemind_bus_client/client.py`).
+- **`HiveMessage`**: The fundamental message unit of the HiveMind protocol (`hivemind_bus_client/message.py`).
+- **`NodeIdentity`**: Manages device credentials, keys, and identity settings (`hivemind_bus_client/identity.py`).
 
 ## Quick Start
 
@@ -27,6 +27,9 @@ from ovos_bus_client.message import Message
 
 # Initialize the client
 client = HiveMessageBusClient(key="my_access_key", password="my_password", host="ws://127.0.0.1")
+
+# The hub must first grant this client the message types it sends:
+#   hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
 
 # Connect and block until handshake is complete
 client.connect()

--- a/docs/message_types.md
+++ b/docs/message_types.md
@@ -4,8 +4,10 @@ HiveMind communication is based on the `HiveMessage` class (defined in `hivemind
 ## `HiveMessage` Fields
 
 - **`msg_type`**: A value from the `HiveMessageType` enum.
-- **`payload`**: The actual message (an OVOS `Message` for BUS types, `bytes` for BIN types).
-- **`context`**: Metadata used for routing and tracking (optional).
+- **`payload`**: The actual message (an OVOS `Message` for BUS types, `bytes` for BINARY types).
+- **`metadata`**: Auxiliary dict carried with the message (for example `sample_rate`, `lang`).
+- **`route`**: Ordered hop history. See Route Metadata below.
+- **`target_peers`**, **`target_site_id`**, **`target_public_key`**: Routing hints.
 
 ## `HiveMessageType` (The Routing Modes)
 
@@ -14,11 +16,11 @@ The `msg_type` (defined in `hivemind_bus_client.message.HiveMessageType`) dictat
 | Type | Purpose | Use Case |
 |---|---|---|
 | **`BUS`** | Standard message for the AI | Utterances, intent triggers, speak events. |
-| **`BIN`** | Raw binary data | Audio streams for STT/TTS, file transfers. |
+| **`BINARY`** | Raw binary data | Audio streams for STT/TTS, file transfers. |
 | **`ESCALATE`** | Upstream request | Used by a Slave Mind to ask a Master Mind for help. |
 | **`BROADCAST`** | Downstream flood (admin only) | Master pushes a message to all connected satellites. |
 | **`PROPAGATE`** | Bidirectional flood | Forwards to all peers in both directions. |
-| **`INTERCOM`** | End-to-end hybrid-encrypted | AES-GCM payload + RSA-encrypted ephemeral key. Only trusted peers or explicit targets are injected. |
+| **`INTERCOM`** | End-to-end hybrid-encrypted | AES-GCM payload + RSA-encrypted ephemeral key. Only trusted peers or explicit targets are injected. Has no binary wire code, so it always travels as a text frame. |
 | **`QUERY`** | Request-response upstream | Like ESCALATE, but first answering node sends a response back. Stops propagation on answer. |
 | **`CASCADE`** | Request-response flood | Like PROPAGATE, but expects responses from ALL nodes. Supports disambiguation. |
 | **`PING`** | Network discovery flood | Each node responds with its own PING (same `flood_id`). Carried inside PROPAGATE. Route metadata = hive path. |
@@ -30,7 +32,7 @@ The `msg_type` (defined in `hivemind_bus_client.message.HiveMessageType`) dictat
 
 QUERY propagates upstream like ESCALATE, but stops as soon as one node can respond.
 
-**Satellite behavior** (`HiveMindSlaveProtocol.handle_query`, `protocol.py:311`):
+**Satellite behavior** (`HiveMindSlaveProtocol.handle_query`, `protocol.py`):
 - Inner payload must be `BUS` or `INTERCOM`.
 - `BUS` payloads are dispatched to `handle_bus`.
 - `INTERCOM` payloads are dispatched to `handle_intercom`.
@@ -61,9 +63,9 @@ def on_speak(msg):
 
 CASCADE propagates like PROPAGATE (bidirectional flood) but expects responses from all reachable nodes. Responses are optional. Nodes that cannot answer simply stay silent.
 
-**Satellite behavior** (`HiveMindSlaveProtocol.handle_cascade`, `protocol.py:436`):
+**Satellite behavior** (`HiveMindSlaveProtocol.handle_cascade`, `protocol.py`):
 
-Responses are buffered in a `CascadeAggregator` (`protocol.py:21`). After `cascade_timeout` seconds (default 5.0) **or** when the number of responses reaches the known node count from `hive_mapper`, the `cascade_select_callback` picks the best response and emits it on the internal bus.
+Responses are buffered in a `CascadeAggregator` (`protocol.py`). After `cascade_timeout` seconds (default 5.0) **or** when the number of responses reaches the known node count from `hive_mapper`, the `cascade_select_callback` picks the best response and emits it on the internal bus.
 
 - Inner payload must be `BUS` or `INTERCOM`.
 - Default select callback returns the first response.
@@ -151,7 +153,7 @@ def on_ping(message: HiveMessage) -> None:
 client.on(HiveMessageType.PING, on_ping)
 ```
 
-For automated topology collection use `HiveMapper` from `hivemind_core.hive_map`.
+For automated topology collection use `HiveMapper` from `hivemind_bus_client.hive_map`.
 
 ---
 
@@ -193,7 +195,7 @@ for hop in message.route:
 
 ### Serialization
 
-Route survives `as_dict()` → `deserialize()` roundtrips. The `route` field is included in JSON serialization and restored on deserialization (`message.py:208-231`).
+Route survives `as_dict()` → `deserialize()` roundtrips. The `route` field is included in JSON serialization and restored on deserialization (`message.py`).
 
 ---
 
@@ -202,7 +204,7 @@ Route survives `as_dict()` → `deserialize()` roundtrips. The `route` field is 
 Before being sent over the network, `HiveMessage` objects are:
 1. **Serialized**: Using functions in `hivemind_bus_client.serialization` (`get_bitstring`, `decode_bitstring`).
 2. **Encrypted**: Using AES-256-GCM via functions in `hivemind_bus_client.encryption`.
-3. **Encoded**: Frequently using Z85+Base91 for safe text transport via `hivemind_bus_client.encodings`.
+3. **Encoded**: Frequently using Z85 or Base91 for safe text transport. The encoders come from the `z85base91` package.
 
 ### Examples
 
@@ -217,9 +219,15 @@ hive_msg = HiveMessage(HiveMessageType.BUS,
 
 #### Sending Binary Audio Data
 ```python
+from hivemind_bus_client.message import HiveMindBinaryPayloadType
+
 audio_bytes = b"..." # Raw PCM audio
-hive_msg = HiveMessage(HiveMessageType.BIN, audio_bytes)
+hive_msg = HiveMessage(HiveMessageType.BINARY, audio_bytes,
+                       bin_type=HiveMindBinaryPayloadType.RAW_AUDIO)
 ```
+
+The enum member is `BINARY`. `HiveMessageType.BIN` does not exist. The string on the wire
+is `"bin"`.
 
 ---
 [← Fakes](fakebus.md) · [Home](index.md) · [Binary Serialization →](serialization.md)

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -4,7 +4,7 @@ The HiveMind binary serialization protocol (`hivemind_bus_client/serialization.p
 
 ## Protocol Version
 
-Current version: **1** (`PROTOCOL_VERSION`, `serialization.py:12`).
+Current version: **1** (`PROTOCOL_VERSION`, `serialization.py`).
 
 Decoding a bitstring with an unsupported version raises `UnsupportedProtocolVersion` (`exceptions.py`).
 
@@ -29,18 +29,18 @@ All fields are packed MSB-first. The bitstring is left-padded with `0` bits to r
 
 | Field | Bits | Description | Source |
 |-------|------|-------------|--------|
-| Padding | 0+ | Leading `0` bits for byte alignment | `_get_bitstring_v1`, `serialization.py:78-80` |
-| Start marker | 1 | Always `1`. Decoder skips `0`s until it finds this | `serialization.py:54` |
-| Versioned flag | 1 | `1` = next 8 bits are a protocol version, `0` = assume current version | `serialization.py:55` |
-| Protocol version | 8 (optional) | Only present when versioned=1. Integer protocol version | `serialization.py:57` |
-| Message type | 5 | Index into `_INT2TYPE` mapping (13 types, 0-12) | `serialization.py:58`, `_INT2TYPE`, `serialization.py:16-28` |
-| Compressed | 1 | `1` = payload is zlib-compressed | `serialization.py:59` |
-| Metadata length | 8 | Number of **bytes** of metadata that follow | `serialization.py:63` |
-| Metadata | N×8 | JSON-encoded dict, optionally zlib-compressed | `serialization.py:64` |
-| Binary subtype | 4 (conditional) | Only for `BINARY` type. Maps to `HiveMindBinaryPayloadType` | `serialization.py:68-69` |
-| Payload | remaining | JSON string (text types) or raw bytes (BINARY type) | `serialization.py:71-76` |
+| Padding | 0+ | Leading `0` bits for byte alignment | `_get_bitstring_v1`, `serialization.py` |
+| Start marker | 1 | Always `1`. Decoder skips `0`s until it finds this | `serialization.py` |
+| Versioned flag | 1 | `1` = next 8 bits are a protocol version, `0` = assume current version | `serialization.py` |
+| Protocol version | 8 (optional) | Only present when versioned=1. Integer protocol version | `serialization.py` |
+| Message type | 5 | Index into `_INT2TYPE` mapping (13 types, 0-12) | `serialization.py`, `_INT2TYPE`, `serialization.py` |
+| Compressed | 1 | `1` = payload is zlib-compressed | `serialization.py` |
+| Metadata length | 8 | Number of **bytes** of metadata that follow | `serialization.py` |
+| Metadata | N×8 | JSON-encoded dict, optionally zlib-compressed | `serialization.py` |
+| Binary subtype | 4 (conditional) | Only for `BINARY` type. Maps to `HiveMindBinaryPayloadType` | `serialization.py` |
+| Payload | remaining | JSON string (text types) or raw bytes (BINARY type) | `serialization.py` |
 
-### Type Map (`_INT2TYPE`, `serialization.py:16-28`)
+### Type Map (`_INT2TYPE`, `serialization.py`)
 
 | Integer | HiveMessageType |
 |---------|-----------------|
@@ -73,7 +73,7 @@ that error, log it, and drop the frame rather than crashing.
 > the two is a wire-breaking change reserved for a coordinated spec
 > revision; only the unassigned-code rejection (13-31) is enforced here.
 
-### Binary Payload Subtypes (`HiveMindBinaryPayloadType`, `message.py:32-41`)
+### Binary Payload Subtypes (`HiveMindBinaryPayloadType`, `message.py`)
 
 | Integer | Subtype | Description |
 |---------|---------|-------------|
@@ -87,7 +87,7 @@ that error, log it, and drop the frame rather than crashing.
 
 ## Public API
 
-### `get_bitstring()`, `serialization.py:31`
+### `get_bitstring()`, `serialization.py`
 
 Encode a `HiveMessage` to a `BitArray`.
 
@@ -107,9 +107,9 @@ bitstr = get_bitstring(
 # Returns: BitArray, call .bytes for raw bytes
 ```
 
-When `compressed=None`, both compressed and uncompressed encodings are generated and the smaller one is returned (`serialization.py:36-41`).
+When `compressed=None`, both compressed and uncompressed encodings are generated and the smaller one is returned (`serialization.py`).
 
-### `decode_bitstring()`, `serialization.py:85`
+### `decode_bitstring()`, `serialization.py`
 
 Decode raw bytes back to a `HiveMessage`.
 
@@ -119,7 +119,14 @@ from hivemind_bus_client.serialization import decode_bitstring
 hive_msg = decode_bitstring(raw_bytes)  # returns HiveMessage
 ```
 
-### `mycroft2bitstring()`, `serialization.py:129`
+### `BINARY_ENCODABLE_TYPES`, `serialization.py`
+
+The frozen set of message types that have a 5-bit wire code. `INTERCOM` is not in it: it
+has never had a code, so it can only travel as a text frame. `_get_bitstring_v1` raises
+`ValueError` for a type outside this set instead of relabelling the frame as `THIRDPRTY`,
+which is what it used to do. Senders check the set before they pick a framing.
+
+### `mycroft2bitstring()`, `serialization.py`
 
 Convenience wrapper: encode an OVOS `Message` as a `BUS`-type bitstring, using `msg.context` as metadata.
 
@@ -142,7 +149,9 @@ To implement a compatible encoder/decoder:
 3. JSON-encode metadata and non-binary payloads as UTF-8 before compression
 4. Left-pad with `0` bits to byte-align, then prepend a `1` start marker
 5. For `BINARY` messages, the 4-bit subtype appears before the raw payload bytes
-6. Test against the Python reference implementation using cross-platform test vectors (`test/unittests/vectors.json`)
+6. Test against the Python reference implementation using the cross-platform vectors that
+   `HiveMind-js/test/generate_vectors.py` produces. `tests/test_serialization.py` loads
+   them and skips when the file is absent
 
 ---
 [← Message Types](message_types.md) · [Home](index.md) · [Binary Handlers →](binary_handlers.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@ This guide walks through installing the library, registering a satellite on a hu
 ## Prerequisites
 
 - A running [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub (the machine that hosts the OVOS skill engine)
-- Python 3.9+ on the satellite machine
+- Python 3.10+ on the satellite machine
 - Network access from the satellite to the hub on port 5678 (WebSocket) or 5679 (HTTP)
 
 ## 1. Install the library
@@ -25,17 +25,30 @@ hivemind-core add-client --name "living-room-satellite"
 Output:
 
 ```
-Added satellite: living-room-satellite
-  access-key : 42caf3d2405075fb9e7a4e1ff44e4c4f
-  password   : 5ae486f7f1c26bd4645bd052e4af3ea3
+Credentials added to database!
+
+Node ID: 1
+Friendly Name: living-room-satellite
+Access Key: 42caf3d2405075fb9e7a4e1ff44e4c4f
+Password: 5ae486f7f1c26bd4645bd052e4af3ea3
 ```
 
 Keep the access key and password. You need them on the satellite.
 
-To give the satellite admin rights (able to send BROADCAST messages):
+To give the satellite admin rights (able to send BROADCAST messages), pass the node id:
 
 ```bash
-hivemind-core make-admin --name "living-room-satellite"
+hivemind-core make-admin 1
+```
+
+## 2b. Grant the message types the satellite sends
+
+A new client has an empty whitelist and the hub denies everything it sends, binary
+payloads included. Admin clients are no exception. Grant the types now:
+
+```bash
+hivemind-core allow-msg "recognizer_loop:utterance" 1
+hivemind-core allow-msg "speak" 1
 ```
 
 ## 3. Save credentials on the satellite
@@ -61,11 +74,18 @@ For an encrypted (TLS) connection use `wss://` instead of `ws://`. The library a
 hivemind-client ping --host ws://192.168.1.10 --port 5678
 ```
 
-A successful response looks like:
+`ping` floods the hive and prints the nodes that answered, as an ASCII tree:
 
 ```
-Pong from hub (192.168.1.10:5678), RTT 12 ms
+== connected to HiveMind, sending PING (timeout=5.0s)
+  PING from living-room-hub::def456  site=living-room
+
+== Hive Map ==
+[self] living-room-satellite::abc123
+└── living-room-hub::def456  site=living-room  latency=12ms
 ```
+
+Add `--json` for the raw topology instead.
 
 ## 5. Open an interactive terminal
 
@@ -148,7 +168,9 @@ RuntimeError: timed out waiting for handshake
 The TCP connection opened but the hub rejected or did not complete the handshake. Common causes:
 
 - Wrong access key or password: re-run `hivemind-core add-client` and update `set-identity`
-- The satellite's IP is blocked: check `hivemind-core blacklist-client`
+- The access key was deleted on the hub: check `hivemind-core list-clients`
+- The hub requires a higher protocol version than this client offers: check
+  `min_protocol_version` in the hub's `server.json`
 - Firewall is stateful and drops the upgrade: ensure WebSocket upgrades are not filtered
 
 ### Decryption error
@@ -161,13 +183,15 @@ The `password` does not match what the hub stored for this access key. The hands
 
 ### Multiple satellites on the same machine
 
-Each satellite needs its own `NodeIdentity`. Pass a custom identity file path:
+Each satellite needs its own `NodeIdentity`. Pass a custom identity store:
 
 ```python
+from json_database import JsonConfigXDG
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client import HiveMessageBusClient
 
-identity = NodeIdentity(identity_file="/etc/hivemind/kitchen-satellite.json")
+identity = NodeIdentity(
+    identity_file=JsonConfigXDG("kitchen-satellite", subfolder="hivemind"))
 identity.access_key     = "..."
 identity.password       = "..."
 identity.default_master = "ws://192.168.1.10"

--- a/examples/chat.py
+++ b/examples/chat.py
@@ -5,6 +5,12 @@ from hivemind_bus_client.message import HiveMessage, HiveMessageType
 from hivemind_bus_client.client import HiveMessageBusClient
 
 LOG.set_level("DEBUG")
+
+# Before this runs, the hub must grant this client the message types it sends:
+#   hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
+#   hivemind-core allow-msg "speak" <node_id>
+# A new client has an empty whitelist and the hub denies everything it sends.
+
 # not passing args so it uses identity file
 client = HiveMessageBusClient()
 client.connect() # establish a secure end-to-end encrypted connection

--- a/examples/decorators.py
+++ b/examples/decorators.py
@@ -5,10 +5,17 @@ from hivemind_bus_client import HiveMessageBusClient, HiveMessage, \
 from hivemind_bus_client.decorators import on_payload, on_escalate, \
     on_shared_bus, on_ping, on_broadcast, on_propagate, on_mycroft_message
 
-key = "super_secret_access_key"
-crypto_key = "ivf1NQSkQNogWYyr"
+# Before this runs, the hub must grant this client the message types it sends:
+#   hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
+#   hivemind-core allow-msg "speak" <node_id>
+# A new client has an empty whitelist and the hub denies everything it sends.
 
-bus = HiveMessageBusClient(key, crypto_key=crypto_key)
+# the access key travels down the wire as an access token
+key = "super_secret_access_key"
+# the password derives the session key during the handshake
+password = "super_secret_password"
+
+bus = HiveMessageBusClient(key, password=password)
 
 bus.run_in_thread()
 

--- a/examples/hivemind.py
+++ b/examples/hivemind.py
@@ -4,10 +4,17 @@ from hivemind_bus_client.decorators import on_hive_message
 from ovos_bus_client import Message
 from time import sleep
 
-key = "ivf1NQSkQNogWYyr"
-crypto_key = "ivf1NQSkQNogWYyr"
+# Before this runs, the hub must grant this client the message types it sends:
+#   hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
+#   hivemind-core allow-msg "speak" <node_id>
+# A new client has an empty whitelist and the hub denies everything it sends.
 
-bus = HiveMessageBusClient(key, crypto_key=crypto_key, ssl=False)
+# the access key travels down the wire as an access token
+key = "super_secret_access_key"
+# the password derives the session key during the handshake
+password = "super_secret_password"
+
+bus = HiveMessageBusClient(key, password=password)
 
 bus.run_in_thread()
 

--- a/examples/mycroft_api.py
+++ b/examples/mycroft_api.py
@@ -2,13 +2,17 @@ from hivemind_bus_client import HiveMessageBusClient, HiveMessage, \
     HiveMessageType
 from ovos_bus_client import Message
 
-# these should never be equal! one travels down the wire and is an access token
-key = "ivf1NQSkQNogWYyr"
-# the other is a pre-shared encryption key for a crude initial e2e encryption
-# NOTE: needs to be exactly 16chars
-crypto_key = "ivf1NQSkQNogWYyr"
+# Before this runs, the hub must grant this client the message types it sends:
+#   hivemind-core allow-msg "recognizer_loop:utterance" <node_id>
+#   hivemind-core allow-msg "speak" <node_id>
+# A new client has an empty whitelist and the hub denies everything it sends.
 
-bus = HiveMessageBusClient(key, crypto_key=crypto_key, ssl=False)
+# these are never equal! the access key travels down the wire as an access token
+key = "super_secret_access_key"
+# the password derives the session key during the handshake
+password = "super_secret_password"
+
+bus = HiveMessageBusClient(key, password=password)
 bus.run_in_thread()
 
 # simulate a user utterance


### PR DESCRIPTION
QA pass over `README.md`, `docs/`, and `examples/`. Every command, flag, path, module
name, and code snippet was checked against the source on `dev`. No library code changed;
`examples/` did, because two of the four examples could not run.

## Blocker — the documented code does not run

- **`examples/hivemind.py` and `examples/mycroft_api.py` passed `ssl=False`** to
  `HiveMessageBusClient`. There is no `ssl` parameter (the TLS knob is `self_signed`, and
  the scheme comes from the host URL). Both examples raised `TypeError` on the
  constructor. Removed. Both also used the deprecated `crypto_key`, and
  `examples/hivemind.py` set it to the same value as the access key while
  `examples/mycroft_api.py` warned in a comment that the two must never be equal. All
  examples now use `password`.
- **`docs/message_types.md` used `HiveMessageType.BIN`.** The member is `BINARY` (the wire
  string is `"bin"`). The snippet raises `AttributeError`. The type table had the same
  error.
- **`docs/client_api.md` documented an `@with_hivemind` decorator.** It does not exist
  anywhere in the package. Replaced with a real decorator example.
- **`docs/setup.md` ran `hivemind-core make-admin --name "living-room-satellite"`.**
  `make-admin` takes a node id argument and has no options.
- **`docs/setup.md` called `NodeIdentity(identity_file="/etc/hivemind/kitchen.json")`.**
  The type hint says `str`, but the value is used directly as a dict-like store, so a path
  string fails on the first `.get`. Documented the form that works (a `JsonConfigXDG`).
  The type hint is a code bug and is left for a separate PR.

## Blocker — the onboarding path leaves the reader locked out

README quickstart, `docs/setup.md`, `docs/index.md`, `docs/examples.md`, and all four
files in `examples/` registered a client on the hub and then sent
`recognizer_loop:utterance`. `hivemind-core add-client` creates a client with an empty
`allowed_types`, so the hub denies everything, and since HiveMind-core#171 that includes
binary. Added the `allow-msg` grant step to each, plus a troubleshooting entry for the
`hive.policy.denied` reply.

## High — wrong paths, wrong modules, dead links

- The identity file is `~/.config/hivemind/_identity.json`. `docs/cli_guide.md` and
  `docs/client_api.md` both said `~/.config/hivemind-core/identity.json`.
- `HiveMapper` lives in `hivemind_bus_client.hive_map`. `docs/cli_guide.md` and
  `docs/message_types.md` pointed at `hivemind_core.hive_map`.
- `docs/message_types.md` cited a `hivemind_bus_client.encodings` module. No such module;
  the encoders come from `z85base91`.
- The README linked `HiveMind-core/blob/dev/docs/whitepaper.md`, which does not exist.
  Retargeted to `docs/protocol.md`.
- `docs/serialization.md` pointed cross-language implementors at
  `test/unittests/vectors.json`. The directory is `tests/`, and the vectors come from
  `HiveMind-js/test/generate_vectors.py`.

## High — stale behavior

- `ping` prints an ASCII hive map. `docs/setup.md` showed `Pong from hub ... RTT 12 ms`,
  which the command has never printed since PONG was removed. `docs/cli_guide.md` showed
  `rtt=` in the tree (the renderer prints `latency=`) and `pong_timestamp` in the JSON
  (`to_dict()` emits `timestamp`, `latency_ms`, `public_key`, `lang`, `trusted`).
- `docs/setup.md` told readers to check `hivemind-core blacklist-client`. No such command.
  Replaced with the real failure causes, including a `min_protocol_version` mismatch.
- Documented the reconnect worker and `connect(handshake_max_retries=...)` from #141.
- Documented that INTERCOM has no assigned wire code, so it always travels as a text
  frame, and that `emit()` raises `ValueError` for an unencodable type instead of
  relabelling it `THIRDPRTY` (#151). Added `BINARY_ENCODABLE_TYPES` to
  `docs/serialization.md`.
- `docs/cli_guide.md` described `propagate` as a downstream broadcast. It floods in both
  directions.

## Medium

- `docs/cli.md` omitted `ping`, `test-identity`, and `reset-pgp`, and every option table
  was missing flags (`--host`/`--port` on `set-identity`, `--password`/`--siteid` on
  `terminal` and `send-mycroft`). Added, checked against the click definitions.
- `HiveMessage` field list in `docs/message_types.md` claimed a `context` field. There is
  none. Replaced with `metadata`, `route`, and the target hints.
- Python version: README said 3.9 with a note that the async extra needs 3.10.
  `pyproject.toml` requires 3.10 for everything. Same fix in `docs/setup.md`.
- Added `THIRDPRTY` to the README message-type table.

## Low

- Stripped 93 `file.py:NNN` citations across `docs/`. Spot checks found every one had
  drifted (`client.py:93` for a class now at 107, `client.py:348` for `emit` now at 562,
  and so on). File names kept; line numbers dropped.

## Verified correct, left alone

- Every `hivemind-client` subcommand name and every flag, against the click group.
- `docs/api.md` in full: all `HiveMessage` properties (including `target_public_key`), the
  complete `HiveMessageType` and `HiveMindBinaryPayloadType` tables, every
  `HiveMessageBusClient` method signature and default (`wait_for_payload` defaulting to
  `THIRDPRTY`, `wait_for_response` falling through to a payload waiter for a Mycroft
  message), all nine decorators, the `NodeIdentity` trusted-key API, `HiveMapper`, and the
  `hybrid_encrypt`/`hybrid_decrypt` pair. Only the line numbers were wrong.
- `docs/serialization.md` wire format, the `_INT2TYPE` table, and the unassigned-code
  rejection for 13-31 all match #145.
- `docs/async_client.md`: every method on `AsyncHiveMessageBusClient` exists and the
  constructor signature matches.
- `docs/examples.md`: every snippet checked against the current API.
- HTTP client port 5679, matching the new `hivemind-http-protocol` default.
- The README security section, the satellite-spectrum table, and the identity field
  reference in `docs/identity.md`.

## Not fixed

- `NodeIdentity.__init__` is annotated `identity_file: Optional[str]` but the value must
  be a `JsonConfigXDG`-like object. That is a code bug, not a docs bug.
- `docs/cli.md` and `docs/cli_guide.md` are two CLI references with different depth. Both
  are now correct, but merging them is a restructure.

## AI transparency

Written by Claude Opus, under Claude Fable 5 orchestration. Every claim was checked
against the source in this branch, and all four examples were byte-compiled. All touched
files pass `ste_lint.py` with zero SLOP-category violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup, API, CLI, client, serialization, message, and troubleshooting guides.
  - Documented Python 3.10+ support, encrypted handshakes, retry options, identity commands, and updated connection behavior.
  - Added guidance for message whitelists, policy denials, permissions, and default-deny behavior.
  - Clarified message types, binary handling, `INTERCOM` transport, routing fields, and protocol rejection.
  - Refreshed examples with separate access credentials and handshake passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->