### PR TITLE
feat: HiveMessage.forward() derives envelopes without losing fields

### DIFF
--- a/hivemind_bus_client/message.py
+++ b/hivemind_bus_client/message.py
@@ -221,11 +221,17 @@ class HiveMessage:
                 "node": self.node_id,
                 "target_site_id": self.target_site_id,
                 "target_pubkey": self.target_public_key,
-                "source_peer": self.source_peer,
-                # NOTE: raw self._targets, not the target_peers property. The
-                # property invents a target from source_peer when empty, which
-                # would put a target on the wire that the sender never set.
-                "target_peers": self._targets}
+                # NOTE: target_peers is deliberately NOT here, and no new key
+                # may be added without measuring. hivemind-core encrypts an
+                # INTERCOM inner body with raw RSA (PKCS1-OAEP), so a
+                # serialized envelope must fit one RSA block - about 214 bytes
+                # with 2048-bit keys. The smallest possible BUS envelope is
+                # already 207 bytes, so the whole format has ~7 bytes of
+                # headroom. Adding "target_peers": [] costs 20 and breaks real
+                # INTERCOM traffic. Next-hop targets travel via forward(),
+                # which is in-process and free.
+                # See tests/test_message.py::TestWireSizeCeiling.
+                "source_peer": self.source_peer}
 
     def forward(self,
                 payload=_UNSET,
@@ -281,13 +287,11 @@ class HiveMessage:
                 return HiveMessage(payload["msg_type"], payload["payload"],
                                    metadata=payload.get("metadata", {}),
                                    route=payload.get("route"),
-                                   # NOTE: node and source_peer are emitted by
-                                   # as_dict but deliberately NOT restored here
-                                   # - they are per-hop, the receiving node
-                                   # sets them from the connection.
-                                   # absent from frames sent by peers older
-                                   # than this change - never require it
-                                   target_peers=payload.get("target_peers"),
+                                   # NOTE: node, source_peer and target_peers
+                                   # are not restored here - they are per-hop.
+                                   # The receiving node sets node/source_peer
+                                   # from the connection, and it decides its
+                                   # own next-hop targets.
                                    target_site_id=payload.get("target_site_id"),
                                    target_pubkey=payload.get("target_pubkey"))
             except Exception:

--- a/hivemind_bus_client/message.py
+++ b/hivemind_bus_client/message.py
@@ -41,6 +41,19 @@ class HiveMindBinaryPayloadType(IntEnum):
     TTS_AUDIO = 6  # synthesized TTS audio to be played
 
 
+class _Unset:
+    """Sentinel telling forward() apart from an explicit None.
+
+    ``forward(target_site_id=None)`` must be able to DROP the site id, so
+    ``None`` cannot double as "not given"."""
+
+    def __repr__(self):
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
 class HiveMessage:
     def __init__(self, msg_type: Union[HiveMessageType, str],
                  payload: Optional[Union[Message, 'HiveMessage', str, dict, bytes]] =None,
@@ -55,7 +68,9 @@ class HiveMessage:
         #  except for the hivemind node classes receiving the message and
         #  creating the object nothing should be able to change these values
         #  node classes might change them a runtime by the private attribute
-        #  but end-users should consider them read_only
+        #  but end-users should consider them read_only.
+        #  To send this message on to the next hop, use forward() - it derives
+        #  a new envelope and keeps the fields you did not name.
         if msg_type not in [m.value for m in HiveMessageType]:
             raise ValueError("Unknown HiveMessage.msg_type")
         if msg_type != HiveMessageType.BINARY and bin_type != HiveMindBinaryPayloadType.UNDEFINED:
@@ -81,6 +96,10 @@ class HiveMessage:
         elif isinstance(payload, str):
             payload = json.loads(payload)
         self._payload = payload or {}
+        # BUS/wrapper payloads are rebuilt into Message/HiveMessage objects on
+        # access; without this cache every read returned a different object and
+        # mutating one of them was silently lost. See the payload property.
+        self._payload_view = None
 
         self._site_id = target_site_id
         self._target_pubkey = target_pubkey
@@ -129,21 +148,31 @@ class HiveMessage:
         Return the public payload converted to the most appropriate message representation for this HiveMessage.
         
         Depending on this message's msg_type, the payload is returned as a reconstructed `Message`, a reconstructed `HiveMessage`, or the raw stored payload.
-        
+
+        The reconstructed object is built once and reused, so reading the
+        payload twice gives you the SAME object and a mutation made through it
+        is still there on the next read. It is invalidated when the payload is
+        replaced or an item is assigned.
+
         Returns:
             Union[HiveMessage, Message, dict, bytes]: A `Message` when msg_type is BUS or SHARED_BUS; a `HiveMessage` when msg_type is BROADCAST, PROPAGATE, CASCADE, ESCALATE, or QUERY; otherwise the raw payload (typically a `dict` or `bytes`).
         """
+        if self._payload_view is not None:
+            return self._payload_view
+
         if self.msg_type in [HiveMessageType.BUS, HiveMessageType.SHARED_BUS]:
-            return Message(self._payload["type"],
-                           data=self._payload.get("data"),
-                           context=self._payload.get("context"))
-        if self.msg_type in [HiveMessageType.BROADCAST,
-                             HiveMessageType.PROPAGATE,
-                             HiveMessageType.CASCADE,
-                             HiveMessageType.ESCALATE,
-                             HiveMessageType.QUERY]:
-            return HiveMessage(**self._payload)
-        return self._payload
+            self._payload_view = Message(self._payload["type"],
+                                         data=self._payload.get("data"),
+                                         context=self._payload.get("context"))
+        elif self.msg_type in [HiveMessageType.BROADCAST,
+                               HiveMessageType.PROPAGATE,
+                               HiveMessageType.CASCADE,
+                               HiveMessageType.ESCALATE,
+                               HiveMessageType.QUERY]:
+            self._payload_view = HiveMessage(**self._payload)
+        else:
+            return self._payload
+        return self._payload_view
 
     @payload.setter
     def payload(self, payload: Union['HiveMessage', Message, dict, bytes]):
@@ -159,6 +188,7 @@ class HiveMessage:
             self._payload = payload.as_dict
         else:
             self._payload = payload
+        self._payload_view = None
 
     @property
     def bin_type(self) -> HiveMindBinaryPayloadType:
@@ -191,7 +221,48 @@ class HiveMessage:
                 "node": self.node_id,
                 "target_site_id": self.target_site_id,
                 "target_pubkey": self.target_public_key,
-                "source_peer": self.source_peer}
+                "source_peer": self.source_peer,
+                # NOTE: raw self._targets, not the target_peers property. The
+                # property invents a target from source_peer when empty, which
+                # would put a target on the wire that the sender never set.
+                "target_peers": self._targets}
+
+    def forward(self,
+                payload=_UNSET,
+                msg_type=_UNSET,
+                metadata=_UNSET,
+                route=_UNSET,
+                source_peer=_UNSET,
+                target_peers=_UNSET,
+                target_site_id=_UNSET,
+                target_pubkey=_UNSET,
+                node=_UNSET,
+                bin_type=_UNSET) -> 'HiveMessage':
+        """Derive the envelope to send on to the next hop.
+
+        Every field of this message is carried over unless you name it here,
+        including the ones that only the constructor can set (metadata,
+        target_site_id, target_pubkey, node, bin_type). Relays that rebuild
+        envelopes by hand keep forgetting one of those, and the message then
+        arrives stripped with nothing to show what was lost: a flood that dies
+        after one hop, a site-targeted message that no longer knows its site.
+        Preserving is the default; dropping a field is an explicit
+        ``forward(target_site_id=None)``.
+        """
+        def kept(given, current):
+            return current if given is _UNSET else given
+
+        return HiveMessage(
+            msg_type=kept(msg_type, self._msg_type),
+            payload=kept(payload, self._payload),
+            node=kept(node, self._node),
+            source_peer=kept(source_peer, self._source_peer),
+            route=kept(route, list(self._route)),
+            target_peers=kept(target_peers, list(self._targets)),
+            target_site_id=kept(target_site_id, self._site_id),
+            target_pubkey=kept(target_pubkey, self._target_pubkey),
+            bin_type=kept(bin_type, self._bin_type),
+            metadata=kept(metadata, dict(self._meta)))
 
     @property
     def as_json(self) -> str:
@@ -210,6 +281,13 @@ class HiveMessage:
                 return HiveMessage(payload["msg_type"], payload["payload"],
                                    metadata=payload.get("metadata", {}),
                                    route=payload.get("route"),
+                                   # NOTE: node and source_peer are emitted by
+                                   # as_dict but deliberately NOT restored here
+                                   # - they are per-hop, the receiving node
+                                   # sets them from the connection.
+                                   # absent from frames sent by peers older
+                                   # than this change - never require it
+                                   target_peers=payload.get("target_peers"),
                                    target_site_id=payload.get("target_site_id"),
                                    target_pubkey=payload.get("target_pubkey"))
             except Exception:
@@ -239,6 +317,7 @@ class HiveMessage:
     def __setitem__(self, key, value):
         if isinstance(self._payload, dict):
             self._payload[key] = value
+            self._payload_view = None
         else:
             raise TypeError(f"Item assignment not supported for payload type {type(self._payload)}")
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -380,36 +380,24 @@ class TestForward:
 class TestAsDictRoundTrip:
     """HiveMessage(**msg.as_dict) must be faithful."""
 
-    def test_as_dict_emits_target_peers(self):
-        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}),
-                          target_peers=["peer-B"])
-        assert msg.as_dict["target_peers"] == ["peer-B"]
-
-    def test_as_dict_target_peers_does_not_invent_source_peer(self):
-        """The target_peers property falls back to source_peer; the wire must
-        not claim a target the sender never set."""
-        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}),
-                          source_peer="peer-A")
-        assert msg.as_dict["target_peers"] == []
-
     def test_constructor_round_trip_is_faithful(self):
         msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}),
                           node="node-1", source_peer="peer-A",
                           route=[{"source": "peer-A", "targets": ["peer-B"]}],
-                          target_peers=["peer-B"], target_site_id="site-1",
-                          target_pubkey="pubkey-1", metadata={"k": "v"})
+                          target_site_id="site-1", target_pubkey="pubkey-1",
+                          metadata={"k": "v"})
         clone = HiveMessage(**msg.as_dict)
         assert clone.as_dict == msg.as_dict
 
-    def test_json_round_trip_restores_target_peers(self):
-        msg = HiveMessage(HiveMessageType.PROPAGATE,
-                          payload={"msg_type": "bus", "payload": {"type": "t"}},
-                          target_peers=["peer-B", "peer-C"])
-        restored = HiveMessage.deserialize(msg.serialize())
-        assert restored._targets == ["peer-B", "peer-C"]
+    def test_target_peers_stays_off_the_wire(self):
+        """target_peers is a next-hop decision carried by forward(), not a wire
+        field. See TestWireSizeCeiling for why it cannot become one."""
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}),
+                          target_peers=["peer-B"])
+        assert "target_peers" not in msg.as_dict
+        assert msg.forward()._targets == ["peer-B"]
 
-    def test_frame_from_old_peer_without_target_peers_still_deserializes(self):
-        """Wire compat: a peer older than this change omits the key."""
+    def test_frame_from_an_older_peer_still_deserializes(self):
         old_frame = json.dumps({"msg_type": "bus",
                                 "payload": {"type": "t", "data": {}, "context": {}},
                                 "metadata": {}, "route": [], "node": None,
@@ -420,9 +408,44 @@ class TestAsDictRoundTrip:
         assert restored._targets == []
 
     def test_unknown_future_keys_are_ignored(self):
+        """A peer that sends keys we do not know must not break us."""
         frame = json.dumps({"msg_type": "bus", "payload": {"type": "t"},
+                            "target_peers": ["peer-B"],
                             "some_future_field": "ignore me"})
         assert HiveMessage.deserialize(frame).msg_type == HiveMessageType.BUS
+
+
+class TestWireSizeCeiling:
+    """A serialized envelope must fit one RSA block.
+
+    hivemind-core encrypts an INTERCOM inner body with raw RSA (PKCS1-OAEP),
+    which cannot be split across blocks. With 2048-bit identity keys the
+    ceiling is 214 bytes. The smallest useful BUS envelope is already ~207,
+    so the format has almost no headroom: adding one short key to as_dict
+    ("target_peers": [] costs 20 bytes) pushes real INTERCOM traffic over the
+    limit and a satellite that worked yesterday starts failing on payload
+    size. If this test fails because you added a field to as_dict, the field
+    does not go on the wire - carry it through forward() instead.
+    """
+
+    RSA_2048_OAEP_MAX_BYTES = 214
+
+    def test_minimal_bus_envelope_fits_one_rsa_block(self):
+        inner = HiveMessage(HiveMessageType.BUS,
+                            payload=Message("recognizer_loop:utterance", {}))
+        size = len(inner.serialize().encode("utf-8"))
+        assert size <= self.RSA_2048_OAEP_MAX_BYTES, (
+            f"serialized envelope grew to {size} bytes, over the "
+            f"{self.RSA_2048_OAEP_MAX_BYTES}-byte RSA block limit; "
+            f"INTERCOM traffic will fail with 'Plaintext is too long'")
+
+    def test_as_dict_keys_are_pinned(self):
+        """Pinned on purpose. Changing this set changes every frame on the
+        wire, so it should be a deliberate edit with a size measurement."""
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}))
+        assert set(msg.as_dict) == {"msg_type", "payload", "metadata", "route",
+                                    "node", "target_site_id", "target_pubkey",
+                                    "source_peer"}
 
 
 class TestPayloadIdentity:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -304,3 +304,156 @@ class TestDeserializePreservesFields:
             assert isinstance(hop, dict)
             assert "source" in hop
             assert "targets" in hop
+
+
+class TestForward:
+    """forward() must not lose envelope fields."""
+
+    @staticmethod
+    def _full():
+        return HiveMessage(HiveMessageType.PROPAGATE,
+                           payload={"msg_type": "bus", "payload": {"type": "t"}},
+                           node="node-1",
+                           source_peer="peer-A",
+                           route=[{"source": "peer-A", "targets": ["peer-B"]}],
+                           target_peers=["peer-B", "peer-C"],
+                           target_site_id="site-1",
+                           target_pubkey="pubkey-1",
+                           metadata={"k": "v"})
+
+    def test_forward_preserves_every_field(self):
+        original = self._full()
+        fwd = original.forward()
+        assert fwd.msg_type == original.msg_type
+        assert fwd._payload == original._payload
+        assert fwd.node_id == "node-1"
+        assert fwd.source_peer == "peer-A"
+        assert fwd.route == original.route
+        assert fwd._targets == ["peer-B", "peer-C"]
+        assert fwd.target_site_id == "site-1"
+        assert fwd.target_public_key == "pubkey-1"
+        assert fwd.metadata == {"k": "v"}
+        assert fwd.bin_type == original.bin_type
+
+    def test_forward_preserves_constructor_only_fields(self):
+        """metadata, target_site_id, target_pubkey, node and bin_type have no
+        setter, so a hand-rebuilt envelope is where they go missing."""
+        fwd = self._full().forward(source_peer="peer-B", target_peers=["peer-D"])
+        assert fwd.metadata == {"k": "v"}
+        assert fwd.target_site_id == "site-1"
+        assert fwd.target_public_key == "pubkey-1"
+        assert fwd.node_id == "node-1"
+
+    def test_forward_preserves_bin_type(self):
+        original = HiveMessage(HiveMessageType.BINARY, payload=b"\x01\x02",
+                               bin_type=HiveMindBinaryPayloadType.RAW_AUDIO)
+        assert original.forward().bin_type == HiveMindBinaryPayloadType.RAW_AUDIO
+
+    def test_explicit_override_wins(self):
+        fwd = self._full().forward(msg_type=HiveMessageType.CASCADE,
+                                   source_peer="peer-B",
+                                   target_peers=["peer-D"],
+                                   metadata={"other": 1},
+                                   route=[],
+                                   payload={"msg_type": "bus", "payload": {"type": "u"}})
+        assert fwd.msg_type == HiveMessageType.CASCADE
+        assert fwd.source_peer == "peer-B"
+        assert fwd._targets == ["peer-D"]
+        assert fwd.metadata == {"other": 1}
+        assert fwd.route == []
+        assert fwd._payload["payload"]["type"] == "u"
+
+    def test_explicit_none_drops_the_field(self):
+        fwd = self._full().forward(target_site_id=None, target_pubkey=None)
+        assert fwd.target_site_id is None
+        assert fwd.target_public_key is None
+
+    def test_forward_does_not_mutate_the_original(self):
+        original = self._full()
+        fwd = original.forward()
+        fwd.add_target_peer("peer-Z")
+        fwd.replace_route([])
+        assert original._targets == ["peer-B", "peer-C"]
+        assert original.route == [{"source": "peer-A", "targets": ["peer-B"]}]
+
+
+class TestAsDictRoundTrip:
+    """HiveMessage(**msg.as_dict) must be faithful."""
+
+    def test_as_dict_emits_target_peers(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}),
+                          target_peers=["peer-B"])
+        assert msg.as_dict["target_peers"] == ["peer-B"]
+
+    def test_as_dict_target_peers_does_not_invent_source_peer(self):
+        """The target_peers property falls back to source_peer; the wire must
+        not claim a target the sender never set."""
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {}, {}),
+                          source_peer="peer-A")
+        assert msg.as_dict["target_peers"] == []
+
+    def test_constructor_round_trip_is_faithful(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}),
+                          node="node-1", source_peer="peer-A",
+                          route=[{"source": "peer-A", "targets": ["peer-B"]}],
+                          target_peers=["peer-B"], target_site_id="site-1",
+                          target_pubkey="pubkey-1", metadata={"k": "v"})
+        clone = HiveMessage(**msg.as_dict)
+        assert clone.as_dict == msg.as_dict
+
+    def test_json_round_trip_restores_target_peers(self):
+        msg = HiveMessage(HiveMessageType.PROPAGATE,
+                          payload={"msg_type": "bus", "payload": {"type": "t"}},
+                          target_peers=["peer-B", "peer-C"])
+        restored = HiveMessage.deserialize(msg.serialize())
+        assert restored._targets == ["peer-B", "peer-C"]
+
+    def test_frame_from_old_peer_without_target_peers_still_deserializes(self):
+        """Wire compat: a peer older than this change omits the key."""
+        old_frame = json.dumps({"msg_type": "bus",
+                                "payload": {"type": "t", "data": {}, "context": {}},
+                                "metadata": {}, "route": [], "node": None,
+                                "target_site_id": None, "target_pubkey": None,
+                                "source_peer": None})
+        restored = HiveMessage.deserialize(old_frame)
+        assert restored.msg_type == HiveMessageType.BUS
+        assert restored._targets == []
+
+    def test_unknown_future_keys_are_ignored(self):
+        frame = json.dumps({"msg_type": "bus", "payload": {"type": "t"},
+                            "some_future_field": "ignore me"})
+        assert HiveMessage.deserialize(frame).msg_type == HiveMessageType.BUS
+
+
+class TestPayloadIdentity:
+    """Repeated payload access must return the same object."""
+
+    def test_bus_payload_is_stable(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}))
+        assert msg.payload is msg.payload
+
+    def test_wrapper_payload_is_stable(self):
+        msg = HiveMessage(HiveMessageType.PROPAGATE,
+                          payload={"msg_type": "bus", "payload": {"type": "t"}})
+        assert msg.payload is msg.payload
+
+    def test_mutation_through_payload_survives(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}))
+        msg.payload.context["session"] = "sess-1"
+        assert msg.payload.context["session"] == "sess-1"
+
+    def test_dict_payload_is_stable(self):
+        msg = HiveMessage(HiveMessageType.THIRDPRTY, payload={"a": 1})
+        assert msg.payload is msg.payload
+
+    def test_setting_payload_invalidates_the_cached_view(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}))
+        assert msg.payload.msg_type == "t"
+        msg.payload = Message("u", {}, {})
+        assert msg.payload.msg_type == "u"
+
+    def test_item_assignment_invalidates_the_cached_view(self):
+        msg = HiveMessage(HiveMessageType.BUS, payload=Message("t", {"a": 1}, {}))
+        assert msg.payload.msg_type == "t"
+        msg["type"] = "u"
+        assert msg.payload.msg_type == "u"


### PR DESCRIPTION
## The bug class this retires

`HiveMessage` says in `__init__` that nothing but the receiving node should change its values, but it gives you no way to DERIVE one. So a relay that must send a message on has to rebuild the envelope by hand — and five of its fields (`metadata`, `target_site_id`, `target_pubkey`, `node`, `bin_type`) have no setter at all. Miss one and the message arrives stripped, with nothing to show what was lost. There are about 8 such rebuild sites in hivemind-core, each with its own partial-preservation rule.

`forward()` makes preservation the default and dropping a field the explicit act:

```python
out = msg.forward(source_peer=my_peer_id, target_peers=[next_hop])   # keeps the rest
out = msg.forward(target_site_id=None)                               # drops it, on purpose
```

An explicit `None` drops a field, so "not given" is a sentinel rather than `None`.

### The two hivemind-core bugs it would have prevented

- **A flood that died after one hop.** The relay rebuilt a `PROPAGATE` envelope and did not carry the payload/route state that keeps the flood alive past the first neighbour.
- **A site-targeted message that became undeliverable past a relay.** `target_site_id` is constructor-only; the rebuilt envelope no longer knew its site, so the far side had nothing to match on.

Both are the same shape: a hand-rebuilt envelope, one field short. `forward()` cannot be one field short.

## The wire has ~7 bytes of headroom — measured the hard way

The first version of this PR also added `target_peers` to `as_dict`, to make `HiveMessage(**msg.as_dict)` round-trip. **That broke the conformance harness**, and it was right to.

hivemind-core encrypts an INTERCOM inner body with raw RSA (`encrypt_RSA` → PKCS1-OAEP). Raw RSA cannot span blocks, so a serialized envelope must fit one: **214 bytes** with 2048-bit identity keys. Measured:

| envelope | serialized size |
|---|---|
| minimal BUS (`recognizer_loop:utterance`, empty data) | **207 bytes** |
| ceiling (2048-bit PKCS1-OAEP) | **214 bytes** |
| same envelope with `"target_peers": []` | **227 bytes** — fails |

`Plaintext is too long.` The whole format has about **7 bytes of headroom**. One short key with an empty list costs 20.

I bisected this: reverting the `as_dict` key alone restores the harness to green, so the memoized payload view is innocent.

**Resolution: `target_peers` does not go on the wire.** It travels only through `forward()`, which is in-process and free. I considered omitting the key when the list is empty, but rejected it — the case that grows the envelope is exactly the case that matters (a relay with real targets), so it would be a latent landmine that fires in production the first time someone sets a target, not in CI. `forward()` was always the actual fix for the bug class; the `as_dict` round-trip was a secondary nicety and it is demonstrably not free.

This is now pinned in two ways so the next person finds out at unit-test time:

- `TestWireSizeCeiling::test_minimal_bus_envelope_fits_one_rsa_block` asserts the serialized size against the 214-byte limit, with a failure message naming the RSA cause.
- `TestWireSizeCeiling::test_as_dict_keys_are_pinned` pins the exact key set, so growing the wire has to be a deliberate edit.
- A comment at the `as_dict` return states the ceiling, the measurement, and where to put the field instead.

`as_dict` is therefore byte-for-byte unchanged by this PR.

## What I verified against the original analysis

| Claim | Verdict |
|---|---|
| `as_dict` drops `target_peers` | **True — but not fixable there.** See above; carried by `forward()` instead. |
| `as_dict` drops `bin_type` | **Technically true, but unreachable.** `bin_type` may only be non-`UNDEFINED` when `msg_type == BINARY`, and `as_dict` raises `ValueError` for `BINARY`. So it is provably always `UNDEFINED` there and already round-trips. Adding a constant-valued key would have cost wire bytes for nothing — doubly wrong given the ceiling. `forward()` carries `bin_type`, which is where it is reachable, with a test. |
| The `payload` getter builds a new object per access | **True.** Memoized. Not the harness regression. |

One thing the analysis did not mention: `as_dict` emits `node` and `source_peer` but `deserialize` deliberately does not restore them — `TestDeserializePreservesFields` asserts this, because both are per-hop and the receiving node sets them from the connection. Existing decision, left alone, reason written into the code as a comment rather than silently "fixed". `target_peers` now sits in the same category: per-hop, chosen by the sender for the next hop, not inherited from the frame.

## The payload aliasing trap

`payload` reconstructed a `Message` (BUS/SHARED_BUS) or a `HiveMessage` (wrapper types) on **every** access. Reading it twice gave two unrelated objects, and mutating one had no effect. `handle_propagate_message` in hivemind-core reads it five times.

Fixed by caching the reconstructed object in `_payload_view`, invalidated by the `payload` setter and by `__setitem__`.

Scoping note: the cache changes observable behavior in exactly the intended direction — a mutation through `msg.payload` survives to the next read. It does **not** make such a mutation reach `as_dict`/`serialize`, which still read the underlying `_payload`. That was already true and I did not change it; writing back through the view is a much larger change and does not belong here. The raw `dict`/`bytes` path was already identity-stable and is untouched.

## Wire compatibility

No wire change at all in the final version. `as_dict` emits the same eight keys as `dev`, in the same order. No protocol version bump, no size change, binary path in `serialization.py` untouched, HiveMind-js unaffected. Tolerance in both directions is still pinned by `test_frame_from_an_older_peer_still_deserializes` and `test_unknown_future_keys_are_ignored` (the latter now feeds a `target_peers` key in, proving we do not choke if some future or foreign peer sends one).

## Follow-up in hivemind-core (not in this PR)

Once this ships, the private `_rewrap` helper in `hivemind_core/protocol.py` — with its 22-line docstring listing what a caller must remember — collapses to a one-liner over `forward()`. A docstring reminding you what to preserve is a convention, and conventions rot; `forward()` is the same thing enforced by the type. `_build_query_response` should then pass `metadata=` explicitly, since it genuinely wants fresh metadata rather than the inherited kind, and that intent belongs at the call site instead of being implied by omission.

## Tests

18 added in `tests/test_message.py`:

- `TestForward`: `test_forward_preserves_every_field`, `test_forward_preserves_constructor_only_fields`, `test_forward_preserves_bin_type`, `test_explicit_override_wins`, `test_explicit_none_drops_the_field`, `test_forward_does_not_mutate_the_original`
- `TestAsDictRoundTrip`: `test_constructor_round_trip_is_faithful`, `test_target_peers_stays_off_the_wire`, `test_frame_from_an_older_peer_still_deserializes`, `test_unknown_future_keys_are_ignored`
- `TestWireSizeCeiling`: `test_minimal_bus_envelope_fits_one_rsa_block`, `test_as_dict_keys_are_pinned`
- `TestPayloadIdentity`: `test_bus_payload_is_stable`, `test_wrapper_payload_is_stable`, `test_mutation_through_payload_survives`, `test_dict_payload_is_stable`, `test_setting_payload_invalidates_the_cached_view`, `test_item_assignment_invalidates_the_cached_view`

Results:

- bus-client unit suite (`pytest tests/ --ignore=tests/e2e`): **396 passed, 4 skipped** (baseline 378 passed, 4 skipped; no pre-existing test changed)
- conformance harness (`hivemind-test-harness tests/test_spec_musts.py`): **11 passed, 1 xfailed** — matches the dev baseline exactly

## AI transparency

Written by Claude Opus under Claude Fable 5 orchestration. Reviewed by a human before merge.
