### PR TITLE
fix: keep every route hop that names a source

### DIFF
--- a/hivemind_bus_client/message.py
+++ b/hivemind_bus_client/message.py
@@ -139,7 +139,12 @@ class HiveMessage:
 
     @property
     def route(self) -> List[str]:
-        return [r for r in self._route if isinstance(r, dict) and r.get("targets") and r.get("source")]
+        # HIVEMIND-MSG-1 §5: a hop records AT LEAST the forwarding node in
+        # `source`. `targets` is optional provenance that no consumer reads,
+        # so requiring it here silently dropped spec-minimal hops -- and
+        # because relaying copies this filtered view back over the route,
+        # dropped hops were erased from the message for every later node.
+        return [r for r in self._route if isinstance(r, dict) and r.get("source")]
 
     @property
     def payload(self) -> Union['HiveMessage', Message, dict, bytes]:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -135,14 +135,21 @@ class TestHiveMessageSerialization:
 
 
 class TestHiveMessageRouting:
-    def test_route_filters_incomplete_hops(self):
+    def test_route_keeps_every_hop_that_names_a_source(self):
         hm = HiveMessage(HiveMessageType.PING, {},
                           route=[{"source": "a", "targets": ["b"]},
                                  {"source": "", "targets": []},
-                                 {"source": "c", "targets": []}])
-        # only hops with both source and targets are kept
-        assert len(hm.route) == 1
-        assert hm.route[0]["source"] == "a"
+                                 {"source": "c", "targets": []},
+                                 {"source": "d"}])
+        # MSG-1 §5: a hop records AT LEAST a source. `targets` is optional
+        # provenance, so a hop is kept with an empty targets list and with no
+        # targets key at all. Only a hop naming no source is dropped.
+        assert [h["source"] for h in hm.route] == ["a", "c", "d"]
+
+    def test_route_drops_a_hop_with_no_source(self):
+        hm = HiveMessage(HiveMessageType.PING, {},
+                          route=[{"targets": ["b"]}, "not-a-dict"])
+        assert hm.route == []
 
     def test_target_peers_defaults_to_source(self):
         hm = HiveMessage(HiveMessageType.PING, {},


### PR DESCRIPTION
## The bug

`HiveMessage.route` filtered out any hop without a truthy `targets`:

    return [r for r in self._route if isinstance(r, dict) and r.get("targets") and r.get("source")]

HIVEMIND-MSG-1 §5 says a hop "records **at least** the forwarding node in a `source` field". So a hop written exactly to spec — `{"source": "<pubkey>"}` — was invisible through the property while still sitting in `_route`.

## Why it matters

**It defeats loop suppression.** `_is_routing_loop` in hivemind-core reads this property. Reproduced against current core:

    hop naming this very node, no targets:
      before -> _is_routing_loop == False   (message re-forwarded, flood never terminates)
      after  -> _is_routing_loop == True

**It also erased the evidence.** Relaying copies the *filtered* view back over the route (`_unpack_message`, `_rewrap` both call `replace_route(message.route)`), so a dropped hop was deleted from the message for every downstream node, not merely ignored by one.

This is the same class as the two route bugs fixed today (#162 keyed loop detection on a shared constant; #172 lost envelope fields on rewrap) — a hop's visibility depended on a field unrelated to identity.

## The fix

Require only `source`. `targets` is provenance: nothing in hivemind-core ever indexes a hop's `targets` (grepped every consumer). A hop naming no source is still dropped, as is a non-dict entry.

## Interop note

An implementation written from the spec alone would emit source-only hops and silently lose loop protection against every deployed HiveMind node. That is precisely the failure mode the spec repo exists to prevent.

## The test that pinned it

`test_route_filters_incomplete_hops` asserted the buggy behaviour outright — *"only hops with both source and targets are kept"* — including that `{"source": "c", "targets": []}` is dropped. Corrected to assert every source-bearing hop survives, plus a new case for a hop with no source and a non-dict entry.

## Verification

- bus-client unit suite: **397 passed, 4 skipped**
- harness conformance gate against core `dev`: **11 passed, 1 xfailed** — matches baseline

---
*Written by Claude Opus 4.8 under Claude Fable 5 orchestration, without human oversight.*