### PR TITLE
fix: emit honours the message's own bin_type

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -616,6 +616,13 @@ class HiveMessageBusClient(OVOSBusClient):
                 binarize = self.protocol.binarize and self.binarize
 
             if binarize:
+                # the message carries its own bin_type; an explicit
+                # binary_type argument overrides it. Without this a caller
+                # that set bin_type on the HiveMessage -- the obvious thing
+                # to do -- silently put UNDEFINED on the wire, and the
+                # receiver could not tell audio from a file.
+                if binary_type == HiveMindBinaryPayloadType.UNDEFINED:
+                    binary_type = message.bin_type
                 bitstr = get_bitstring(hive_type=message.msg_type,
                                        payload=message.payload,
                                        compressed=self.compress,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -591,3 +591,41 @@ class TestBuildUrl(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestEmitBinType:
+    """A HiveMessage carries its own bin_type; emit must not discard it."""
+
+    def _emitted_frame(self, message, **kw):
+        from unittest.mock import MagicMock, patch
+        from hivemind_bus_client.client import HiveMessageBusClient
+        c = object.__new__(HiveMessageBusClient)
+        c.connected_event = MagicMock(is_set=lambda: True)
+        c.protocol = MagicMock(binarize=True)
+        c.binarize = True
+        c.compress = False
+        c.noise_transport = None
+        c.crypto_key = None
+        c.client = MagicMock()
+        c.identity = MagicMock(site_id="t")
+        with patch("hivemind_bus_client.client.get_bitstring") as gb:
+            gb.return_value = MagicMock(bytes=b"")
+            c.emit(message, **kw)
+        return gb.call_args.kwargs
+
+    def test_message_bin_type_reaches_the_wire(self):
+        from hivemind_bus_client.message import (
+            HiveMessage, HiveMessageType, HiveMindBinaryPayloadType)
+        m = HiveMessage(HiveMessageType.BINARY, payload=b"\x00" * 8,
+                        bin_type=HiveMindBinaryPayloadType.RAW_AUDIO)
+        assert self._emitted_frame(m)["binary_type"] == \
+            HiveMindBinaryPayloadType.RAW_AUDIO
+
+    def test_explicit_argument_still_wins(self):
+        from hivemind_bus_client.message import (
+            HiveMessage, HiveMessageType, HiveMindBinaryPayloadType)
+        m = HiveMessage(HiveMessageType.BINARY, payload=b"\x00" * 8,
+                        bin_type=HiveMindBinaryPayloadType.RAW_AUDIO)
+        got = self._emitted_frame(
+            m, binary_type=HiveMindBinaryPayloadType.FILE)
+        assert got["binary_type"] == HiveMindBinaryPayloadType.FILE


### PR DESCRIPTION
## Found by live deployment, not by tests

Ran a real `hivemind-core listen` against a real `ovos-messagebus`, connected a real satellite over protocol v3 Noise, and sent a `RAW_AUDIO` binary payload. The ACL denial came back saying:

    {'denied_type': 'binary', 'bin_type': '0', ...}

`0` is UNDEFINED. The payload was constructed as `RAW_AUDIO` (1).

## Cause

`emit()` accepts `binary_type` as a separate argument defaulting to `UNDEFINED`, and passes **that** to `get_bitstring` — `message.bin_type` is never consulted:

    bitstr = get_bitstring(hive_type=message.msg_type,
                           payload=message.payload,
                           binary_type=binary_type,      # the argument, not the message
                           ...)

So the obvious call — setting `bin_type` on the `HiveMessage`, which is the only place the field is modelled — silently ships UNDEFINED.

## Why it matters

The receiver dispatches entirely on that tag: `RAW_AUDIO` to the microphone path, `STT_AUDIO_*` to transcription, `FILE` to disk, `TTS_AUDIO` to playback. Arriving as UNDEFINED, raw audio is unclassified. The binary serialization round-trip itself is fine — the tag was simply never handed to it.

## Fix

Default `binary_type` from `message.bin_type`. An explicit argument still overrides, so every existing caller that passes one is unaffected.

## Verification

- `TestEmitBinType::test_message_bin_type_reaches_the_wire` — fails on dev, passes here
- `TestEmitBinType::test_explicit_argument_still_wins` — guards the override
- unit suite: 52 passed in test_client.py
- **live re-run against the same running server: `bin_type: '1'`**

---
*Written by Claude Opus 4.8 under Claude Fable 5 orchestration, without human oversight.*