### PR TITLE
fix: keep the envelope route across a binary frame

### DIFF
--- a/hivemind_bus_client/serialization.py
+++ b/hivemind_bus_client/serialization.py
@@ -157,13 +157,42 @@ def _decode_bitstring_v1(s):
     payload_len = len(s) - s.pos
     payload = s.read(payload_len)
 
+    route = None
     if not is_bin:
         payload = bytes2str(payload.bytes, compressed)
+        route = _route_from_payload(payload)
     else:
         payload = payload.bytes
 
     return HiveMessage(hive_type, payload,
-                       metadata=meta, bin_type=bin_type)
+                       metadata=meta, bin_type=bin_type, route=route)
+
+
+def _route_from_payload(payload: str):
+    """Recover the envelope ``route`` of a binary frame from its payload.
+
+    The WIRE-1 §4.3 binary frame carries only the message type, the metadata
+    and the payload - it has no field for the envelope ``route``, and the
+    metadata field is limited to 255 bytes, which a real route does not fit.
+    A frame therefore used to arrive with an empty route, and HIVEMIND-MSG-1
+    §5 loop suppression on the receiving node saw nothing: a relay's own hop
+    was gone, so the message could cycle back through that relay undetected.
+
+    A wrapper envelope (ESCALATE, PROPAGATE, CASCADE, ...) carries a
+    serialized HiveMessage as its payload, and a relay keeps the two routes
+    equal - it stamps its hop on the inner message and copies the result onto
+    the envelope. The inner route survives binarization, so it is the
+    authoritative copy and is restored here. Payloads that are not a
+    HiveMessage (a mycroft Message in a BUS frame) have no route and give
+    None, which keeps the previous behaviour.
+    """
+    try:
+        data = json.loads(payload)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(data, dict) and data.get("route"):
+        return data["route"]
+    return None
 
 
 def mycroft2bitstring(msg, compressed=False):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -525,5 +525,35 @@ class TestUnencodableTypes(unittest.TestCase):
                 self.assertEqual(decode_bitstring(bs.bytes).msg_type, msg_type)
 
 
+class TestBinaryFrameRoute(unittest.TestCase):
+    """HIVEMIND-MSG-1 §5: a relayed wrapper envelope must keep its ``route``
+    across the binary framing, or the receiving node cannot see the relay in
+    the route and loop suppression goes blind."""
+
+    def _wrapper(self, route):
+        inner = HiveMessage(HiveMessageType.BUS,
+                            payload=Message("speak", {"utterance": "hi"}),
+                            route=route)
+        outer = HiveMessage(HiveMessageType.ESCALATE, payload=inner)
+        outer.replace_route(route)
+        return outer
+
+    def test_escalate_keeps_route_over_binary_frame(self):
+        route = [{"source": "leaf::abc", "targets": ["leaf::abc"]},
+                 {"source": "PUBKEY-MIDDLE", "targets": ["PUBKEY-MIDDLE"]}]
+        msg = self._wrapper(route)
+        decoded = decode_bitstring(
+            get_bitstring(msg.msg_type, payload=msg.payload,
+                          hivemeta=msg.metadata, compressed=False).bytes)
+        self.assertEqual([h["source"] for h in decoded.route],
+                         ["leaf::abc", "PUBKEY-MIDDLE"])
+
+    def test_bus_frame_without_route_stays_routeless(self):
+        bs = get_bitstring(HiveMessageType.BUS,
+                           payload=Message("speak", {"utterance": "hi"}),
+                           compressed=False)
+        self.assertEqual(decode_bitstring(bs.bytes).route, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The WIRE-1 §4.3 binary frame carries only the message type, the metadata and the payload. It has no field for the envelope `route`, and the metadata field is capped at 255 bytes, which a real route does not fit. On a `binarize: true` link a relayed ESCALATE/PROPAGATE/CASCADE arrives with `route == []`.

HIVEMIND-MSG-1 §5 loop suppression reads that route. With it empty, the receiving node cannot see the relay that forwarded the message, so the message can cycle back through that relay undetected. hivemind-core also copies the envelope route onto the payload on arrival, so the surviving inner route was overwritten with the empty one.

## Evidence

Live three-node mesh, real sockets, Noise v3, master <- middle <- leaf, leaf sends one ESCALATE.

`binarize: false` (default) — correct:

    outer route: ['...::leaf::984f...', '<MIDDLE_PUBKEY>']

`binarize: true` — before this fix:

    outer route: []
    inner route: ['...::leaf::45f4...', '<MIDDLE_PUBKEY>']

After this fix, `binarize: true` matches the text framing again.

## Fix

The wrapper payload is a serialized HiveMessage whose route a relay keeps equal to the envelope route, and that copy survives binarization. The decoder restores the envelope route from it. A payload with no route (a mycroft Message in a BUS frame) keeps the previous behaviour.

No wire change: this is decoder-side only, so old encoders stay compatible.

## Tests

`tests/test_serialization.py::TestBinaryFrameRoute` — the route test fails on the old decoder and passes on the new one; the second test pins that a routeless BUS frame stays routeless. Full suite: 436 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved message routing information when decoding serialized JSON payloads from binary frames.
  * Gracefully handles invalid, non-object, or route-less payloads without disrupting existing decoding behavior.
  * Ensured ordinary messages without routes continue to decode correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->