### PR TITLE
fix: jitter the reconnect backoff so a restart does not resynchronize the fleet

### DIFF
--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -1,4 +1,5 @@
 import json
+import random
 import ssl
 from collections.abc import Callable
 from threading import Event, Lock, Thread, current_thread
@@ -441,7 +442,12 @@ class HiveMessageBusClient(OVOSBusClient):
                 if self._stop_event.is_set():
                     break
 
-                delay = self.retry
+                # Jitter the wait (not the stored retry value) so that a core
+                # restart, which disconnects the whole fleet at once, does not
+                # make every satellite wake up and reconnect at the exact same
+                # instant. Without this the herd never de-phases and keeps
+                # re-forming into synchronized reconnect waves.
+                delay = self.retry * random.uniform(0.5, 1.5)
                 LOG.warning("HiveMind websocket disconnected; reconnecting "
                             "in %.1f seconds", delay)
                 if self._stop_event.wait(delay):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -444,6 +444,80 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
         client.emitter.emit.assert_called_once_with("reconnecting")
         self.assertEqual(client.retry, 2)
 
+    def test_run_forever_jitters_the_wait_but_not_the_retry_series(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 5
+        client._stop_event.wait = MagicMock(return_value=True)
+        client.client.run_forever.side_effect = lambda **kwargs: None
+
+        client.run_forever()
+
+        # the wait delay must have been jittered away from the raw retry value
+        waited_delay = client._stop_event.wait.call_args.args[0]
+        self.assertNotEqual(waited_delay, 5)
+        self.assertGreaterEqual(waited_delay, 5 * 0.5)
+        self.assertLessEqual(waited_delay, 5 * 1.5)
+        # the stored retry value is untouched by jitter: reconnect loop broke
+        # out on wait() returning True, so the exponential bump never ran
+        self.assertEqual(client.retry, 5)
+
+    def test_reconnect_wait_delay_varies_across_calls(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 10
+        waited_delays = []
+
+        def fake_wait(delay):
+            waited_delays.append(delay)
+            return len(waited_delays) >= 5
+
+        client._stop_event.wait = fake_wait
+        second_socket = MagicMock()
+        client.create_client = MagicMock(return_value=second_socket)
+
+        client.run_forever()
+
+        self.assertEqual(len(waited_delays), 5)
+        self.assertTrue(len(set(waited_delays)) > 1)
+        for delay in waited_delays:
+            self.assertGreaterEqual(delay, 0)
+
+    def test_retry_series_stays_clean_exponential_regardless_of_jitter(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 1
+        observed_retries = []
+
+        def fake_wait(delay):
+            observed_retries.append(client.retry)
+            return len(observed_retries) >= 7
+
+        client._stop_event.wait = fake_wait
+        client.create_client = MagicMock(return_value=MagicMock())
+
+        client.run_forever()
+
+        self.assertEqual(observed_retries, [1, 2, 4, 8, 16, 32, 60])
+
+    def test_stop_event_still_interrupts_reconnect_wait_promptly(self):
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 5
+        real_wait = client._stop_event.wait
+
+        def stop_immediately(delay):
+            client._stop_event.set()
+            return real_wait(0)
+
+        client._stop_event.wait = stop_immediately
+        client.create_client = MagicMock()
+
+        client.run_forever()
+
+        self.assertTrue(client._stop_event.is_set())
+        client.create_client.assert_not_called()
+
     def test_reconnecting_listener_failure_does_not_stop_worker(self):
         client = _make_client()
         client.allow_self_signed = False


### PR DESCRIPTION
## Summary
- The reconnect backoff in `_run_forever` was fully deterministic (1s, 2s, 4s, ... capped at 60s). When many satellites lose their connection at the same instant (a core restart), they all wake up at the exact same offsets and reconnect in lockstep, forming synchronized waves that never de-phase — at fleet scale this becomes a self-sustaining reconnect livelock.
- Jitter is now applied to the *wait* (`self._stop_event.wait(delay)`), multiplying the delay by `random.uniform(0.5, 1.5)`. The stored `self.retry` series stays a clean, unjittered exponential (1, 2, 4, ..., 60) — jittering the stored value would compound randomly across attempts and could drift the effective cap.
- The log now reports the actual jittered delay being waited, not the base value.
- Max jittered wait is now `60 * 1.5 = 90s` (was a hard 60s). This is an acceptable tradeoff for de-phasing the herd.

## Sibling check
Grepped this repo and the rest of `~/AgentWorkspaces/hivemind/` for other reconnect/backoff loops with the same deterministic pattern:
- Only one loop in this repo (`hivemind_bus_client/client.py`), now fixed.
- `clients/hivemind-micropython-client/hivemind/client.py` has an analogous `_reconnect()` with a fixed, unjittered `reconnect_ms` delay (no exponential backoff at all) — same herd-sync risk, different repo. Not touched here; flagging for a separate PR.
- No other matches in bridges/core/plugins.

## Test plan
- [x] `test_run_forever_jitters_the_wait_but_not_the_retry_series` — waited delay differs from the raw retry value and falls in `[0.5x, 1.5x]`
- [x] `test_reconnect_wait_delay_varies_across_calls` — waited delays vary across successive reconnect attempts
- [x] `test_retry_series_stays_clean_exponential_regardless_of_jitter` — `self.retry` still follows `1, 2, 4, 8, 16, 32, 60` unaffected by jitter
- [x] `test_stop_event_still_interrupts_reconnect_wait_promptly` — shutdown still interrupts the wait immediately
- [x] Full suite: `pytest tests -q` → 441 passed, 4 skipped