### PR TITLE
fix: a rejected handshake must not brick the satellite

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -109,4 +109,4 @@ For `BUS` messages, `emit()` (`client.py:348`) auto-injects `source`, `platform`
 ## CLI
 
 ### What CLI commands are available?
-`set-identity`, `terminal`, `send-mycroft`, `escalate`, `propagate`, `reset-keys`. Run `hivemind-client --help` for the full list. Source: `scripts.py`
+`set-identity`, `terminal`, `send-mycroft`, `escalate`, `propagate`, `reset-pgp`, `forget-server`, `ping`. Run `hivemind-client --help` for the full list. Source: `scripts.py`

--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ hivemind-client test-identity
 
 # Generate a new RSA key pair for peer-to-peer messages
 hivemind-client reset-pgp
+
+# Forget the pinned key of a master that was reinstalled
+hivemind-client forget-server --host 192.168.1.10 --port 5678
 ```
 
 ## Troubleshooting
@@ -358,6 +361,8 @@ hivemind-client reset-pgp
 **`RuntimeError: timed out waiting for handshake`**: The hub is unreachable or the port is wrong. Verify the hub is running (`hivemind-core listen`) and the firewall allows port 5678. Try `hivemind-client ping` first.
 
 **`got encrypted message, but could not decrypt!`**: The access key or password does not match what was registered on the hub. Re-run `hivemind-core add-client` and update the satellite identity.
+
+**`server Noise static key CHANGED`**: The master is answering with a different encryption key than the one this node pinned. If you reinstalled or restored the master, the pinned key is stale: run `hivemind-client forget-server --host HOST --port PORT` and connect again. If you changed nothing, another machine may be answering at that address. The node keeps retrying and reports this on every attempt.
 
 **Connection drops immediately**: The hub rejected the access key, or the protocol version the client offered is below the hub's `min_protocol_version`. Check hub logs: `journalctl -u hivemind-core -f`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,5 +154,31 @@ hivemind-client reset-pgp
 ```
 
 ---
+
+## `forget-server`
+
+Forget the pinned encryption key of a hivemind-core.
+
+The first time this node connects to a master it records the master's static
+encryption key, and every later connection checks that the key did not change.
+This protects the connection, but it also stops the node when the master
+legitimately changes its key — after a reinstall, a new SD card, or a restore
+from a backup. The log then reports a key mismatch on every attempt.
+
+Forget the old key, then connect again to trust and record the new one.
+
+```bash
+hivemind-client forget-server --host 192.168.1.10 --port 5678
+```
+
+| Option | Description |
+|--------|-------------|
+| `--host` | Host of the master. Defaults to the master in the identity file. |
+| `--port` | Port of the master. Defaults to the port in the identity file. |
+
+Only forget a key you expected to change. If nothing was reinstalled, another
+machine may be answering at that address.
+
+---
 [← Identity & Credentials](identity.md) · [Home](index.md) · [CLI Guide →](cli_guide.md)
 

--- a/hivemind_bus_client/async_client.py
+++ b/hivemind_bus_client/async_client.py
@@ -321,6 +321,15 @@ class AsyncHiveMessageBusClient:
         self.protocol.bind(bus)
         await self.wait_for_handshake()
 
+    async def close_connection(self):
+        """Close the current websocket, leaving the client reusable.
+
+        Counterpart of :meth:`HiveMessageBusClient.close_connection`. The
+        async client has no reconnect loop of its own — the caller drives
+        ``connect()`` — so this is the same as :meth:`close`.
+        """
+        await self.close()
+
     async def close(self):
         """Cleanly close the WebSocket and stop the receive loop."""
         self.handshake_event.clear()
@@ -419,7 +428,7 @@ class AsyncHiveMessageBusClient:
                 # receive counter is now out of sync so the session is dead
                 LOG.exception("rejecting invalid Noise transport message, "
                               "closing connection")
-                asyncio.ensure_future(self.close())
+                asyncio.ensure_future(self.close_connection())
                 return
         elif self.crypto_key:
             if isinstance(message, (bytes, bytearray)):

--- a/hivemind_bus_client/client.py
+++ b/hivemind_bus_client/client.py
@@ -322,6 +322,17 @@ class HiveMessageBusClient(OVOSBusClient):
         if self.protocol is not None:
             self.protocol.reset_connection_state()
 
+    def close_connection(self):
+        """Close the current websocket but keep reconnecting.
+
+        Use this for a connection that has become unusable — a failed
+        handshake, an invalid Noise transport frame — so that
+        ``run_forever()`` returns and the reconnect loop establishes a
+        fresh session. Public :meth:`close` is reserved for an intentional
+        permanent shutdown.
+        """
+        self.client.close()
+
     def close(self):
         """Permanently stop reconnecting and close the websocket."""
         # Serialize the stop request with worker reservation. A worker that is
@@ -491,10 +502,7 @@ class HiveMessageBusClient(OVOSBusClient):
                 # receive counter is now out of sync so the session is dead
                 LOG.exception("rejecting invalid Noise transport message, "
                               "closing connection")
-                # Close this connection so run_forever() establishes a fresh
-                # Noise session. Public close() is reserved for an intentional
-                # permanent shutdown.
-                self.client.close()
+                self.close_connection()
                 return
         elif self.crypto_key:
             # handle binary encryption

--- a/hivemind_bus_client/exceptions.py
+++ b/hivemind_bus_client/exceptions.py
@@ -54,3 +54,7 @@ class DecodingError(HiveMindException):
 class Z85DecodeError(DecodingError):
     """Exception raised for errors in decoding Z85b."""
 
+
+
+class IdentityFileCorrupted(HiveMindException):
+    """ The identity file exists but could not be read """

--- a/hivemind_bus_client/identity.py
+++ b/hivemind_bus_client/identity.py
@@ -1,3 +1,4 @@
+import json
 from os.path import basename, dirname, isfile
 from poorman_handshake.asymmetric.utils import export_RSA_key, create_RSA_key
 from json_database import JsonConfigXDG
@@ -42,9 +43,18 @@ class NodeIdentity:
         path = self.IDENTITY_FILE.path
         if not path or not isfile(path) or self.IDENTITY_FILE:
             return
+        # ask json itself, not a string comparison: a zero byte file is the
+        # likeliest corruption of all (a non atomic write truncates first,
+        # then a power cut lands there) and an empty string would pass any
+        # "looks like {}" test, while a hand written or templated "{ }" is
+        # perfectly valid and must boot
         with open(path, encoding="utf-8") as f:
-            raw = f.read().strip()
-        if raw and raw != "{}":
+            raw = f.read()
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            data = None
+        if not isinstance(data, dict):
             raise IdentityFileCorrupted(
                 f"identity file {path} exists but could not be parsed. "
                 "Refusing to mint a new identity — restore it from a backup "

--- a/hivemind_bus_client/identity.py
+++ b/hivemind_bus_client/identity.py
@@ -1,6 +1,7 @@
-from os.path import basename, dirname
+from os.path import basename, dirname, isfile
 from poorman_handshake.asymmetric.utils import export_RSA_key, create_RSA_key
 from json_database import JsonConfigXDG
+from hivemind_bus_client.exceptions import IdentityFileCorrupted
 from typing import Dict, List, Optional
 
 
@@ -19,7 +20,35 @@ class NodeIdentity:
         Args:
             identity_file (Optional[str]): Path to a custom identity file (default: None, uses default configuration).
         """
-        self.IDENTITY_FILE = identity_file or JsonConfigXDG("_identity", subfolder="hivemind")
+        # an empty store is falsy, so test explicitly: a caller that passes
+        # its own (still empty) file must not silently get the default one
+        if identity_file is None:
+            identity_file = JsonConfigXDG("_identity", subfolder="hivemind")
+        self.IDENTITY_FILE = identity_file
+        self._assert_identity_readable()
+
+    def _assert_identity_readable(self):
+        """Refuse to start with an identity file that exists but did not load.
+
+        JsonStorage fails open: if the file is truncated or otherwise
+        unparseable it logs the error and leaves the dict empty. Every
+        property below would then fall back to a default, the node would
+        call itself "unnamed-node", and because the Noise static key path
+        is derived from the name it would generate a brand new static key.
+        To every peer that pinned the old key the node then looks like an
+        impostor. A node that cannot read its own identity must stop, not
+        come up as a different node.
+        """
+        path = self.IDENTITY_FILE.path
+        if not path or not isfile(path) or self.IDENTITY_FILE:
+            return
+        with open(path, encoding="utf-8") as f:
+            raw = f.read().strip()
+        if raw and raw != "{}":
+            raise IdentityFileCorrupted(
+                f"identity file {path} exists but could not be parsed. "
+                "Refusing to mint a new identity — restore it from a backup "
+                "or delete it to start over as a new node.")
 
     @property
     def name(self) -> str:
@@ -196,6 +225,27 @@ class NodeIdentity:
         keys[node_id] = pubkey
         self.IDENTITY_FILE["pinned_noise_keys"] = keys
         self.save()
+
+    def forget_noise_key(self, node_id: str) -> bool:
+        """Drop the pinned Noise static key for a node id.
+
+        Needed when the peer legitimately changed its static key, which
+        happens whenever a master is reinstalled or restored from a backup.
+        Without this the node refuses every later handshake with that peer.
+
+        Args:
+            node_id: The peer's node identifier.
+
+        Returns:
+            bool: True if a pin was removed, False if there was none.
+        """
+        keys = self.pinned_noise_keys
+        if node_id not in keys:
+            return False
+        keys.pop(node_id)
+        self.IDENTITY_FILE["pinned_noise_keys"] = keys
+        self.save()
+        return True
 
     @property
     def trusted_keys(self) -> Dict[str, str]:

--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -437,8 +437,13 @@ class HiveMindSlaveProtocol:
         pin_id = self._noise_pin_id
         pinned = self.identity.get_pinned_noise_key(pin_id)
         if pinned and transport.remote_static_key != pinned:
-            LOG.error(f"server Noise static key CHANGED for {pin_id} — "
-                      "possible man-in-the-middle, aborting")
+            LOG.error(
+                f"server Noise static key CHANGED for {pin_id} — refusing "
+                "to connect. If you did not reinstall or replace the "
+                "master, another machine may be answering at this address. "
+                "If you did, the pinned key is stale: run "
+                "'hivemind-client forget-server' to drop it and reconnect "
+                "to trust the new key.")
             self._abort_noise("pinned key mismatch")
             return
         if not pinned and transport.remote_static_key:
@@ -465,16 +470,27 @@ class HiveMindSlaveProtocol:
         self.hm.handshake_event.set()
 
     def _abort_noise(self, reason: str):
-        """Fatal handshake failure — reject the connection (§3.4.3)."""
+        """Fatal handshake failure — reject the connection (§3.4.3).
+
+        The connection is dropped, but the client keeps reconnecting. Every
+        abort reason here can be transient or repairable from the other
+        side: a rotated password, a truncated handshake envelope, a master
+        that was reinstalled. A permanent stop would leave the node dead
+        until somebody edits its identity file by hand, and the failure
+        would be logged once and then never again. Retrying re-reports the
+        problem on every attempt and recovers by itself once the cause is
+        fixed. Refusing the connection is what protects the session, not
+        giving up on it.
+        """
         LOG.error(f"aborting protocol v3 connection: {reason}")
         self.noise_handshake = None
         self.hm.noise_transport = None
         try:
-            result = self.hm.close()
+            result = self.hm.close_connection()
             if asyncio.iscoroutine(result):
                 asyncio.ensure_future(result)
         except Exception:
-            pass
+            LOG.exception("failed to close the aborted connection")
 
     def start_handshake(self):
         # negotiated protocol v3 -> the Noise handshake replaces the legacy

--- a/hivemind_bus_client/scripts.py
+++ b/hivemind_bus_client/scripts.py
@@ -200,6 +200,35 @@ def test_identity():
     node.close()
 
 
+@hmclient_cmds.command(help="forget the pinned encryption key of a hivemind-core",
+                       name="forget-server")
+@click.option("--host", help="host of the hivemind-core (default read from identity file)", type=str, default="")
+@click.option("--port", help="port of the hivemind-core (default read from identity file)", type=int, required=False)
+def forget_server(host: str, port: int):
+    """Drop the pinned Noise key of a master.
+
+    A master is pinned the first time it is seen and every later
+    connection checks that the key did not change. Reinstalling the master
+    or restoring it from a backup gives it a new key, so the satellite
+    stops connecting. Forget the old key here, then connect again to trust
+    the new one.
+    """
+    identity = NodeIdentity()
+    host = host or identity.default_master or ""
+    host = host.replace("ws://", "").replace("wss://", "")
+    port = port or identity.default_port or 5678
+    pin_id = f"{host}:{port}"
+    if not host:
+        raise ValueError("please set --host, no default master in the identity file")
+    if identity.forget_noise_key(pin_id):
+        print(f"forgot pinned key for {pin_id}")
+        print("the next connection will trust and pin the key it sees")
+    else:
+        print(f"no pinned key for {pin_id}")
+        known = ", ".join(identity.pinned_noise_keys) or "none"
+        print(f"pinned servers: {known}")
+
+
 @hmclient_cmds.command(help="recreate the private RSA key for inter-node communication", name="reset-pgp")
 def reset_keys():
     identity = NodeIdentity()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -550,6 +550,61 @@ class TestHiveMessageBusClientKeepalive(unittest.TestCase):
         client.create_client.assert_not_called()
 
 
+class TestHiveMessageBusClientHandshakeAbort(unittest.TestCase):
+    """A rejected handshake must not brick the node.
+
+    Aborting the Noise handshake means this connection is refused. It does
+    not mean the node should stop trying: the master may have been
+    reinstalled, the password may have been rotated, the envelope may have
+    been truncated. Public close() is for an intentional shutdown only.
+    """
+
+    def _make_protocol(self, client):
+        from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+
+        return HiveMindSlaveProtocol(hm=client, identity=client.identity,
+                                     site_id="living-room")
+
+    def test_abort_keeps_the_reconnect_loop_alive(self):
+        client = _make_client()
+        protocol = self._make_protocol(client)
+
+        protocol._abort_noise("pinned key mismatch")
+
+        client.client.close.assert_called_once_with()
+        self.assertFalse(client._stop_event.is_set())
+        self.assertIsNone(client.noise_transport)
+
+    def test_client_retries_after_an_abort(self):
+        """End to end: an abort during a session leads to a new socket."""
+        client = _make_client()
+        client.allow_self_signed = False
+        client.retry = 0
+        protocol = self._make_protocol(client)
+        first_socket = client.client
+        first_socket.run_forever.side_effect = (
+            lambda **kwargs: protocol._abort_noise("pinned key mismatch")
+        )
+        second_socket = MagicMock()
+        second_socket.run_forever.side_effect = (
+            lambda **kwargs: client._stop_event.set()
+        )
+        client.create_client = MagicMock(return_value=second_socket)
+
+        client.run_forever()
+
+        first_socket.close.assert_called_once_with()
+        second_socket.run_forever.assert_called_once()
+
+    def test_close_connection_does_not_stop_reconnecting(self):
+        client = _make_client()
+
+        client.close_connection()
+
+        client.client.close.assert_called_once_with()
+        self.assertFalse(client._stop_event.is_set())
+
+
 class TestHiveMessageBusClientOn(unittest.TestCase):
     def test_on_mycroft_event_registers_on_internal_bus(self):
         client = _make_client()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -258,5 +258,96 @@ class TestHiveMessageBusClientInit(unittest.TestCase):
         self.assertRegex(client.session_id, uuid_pattern)
 
 
+class TestPinnedNoiseKeys(unittest.TestCase):
+    """A pinned key must be removable — masters get reinstalled."""
+
+    def _make_identity(self, tmpdir):
+        from json_database import JsonStorage
+        from hivemind_bus_client.identity import NodeIdentity
+        store = JsonStorage(os.path.join(tmpdir, "identity.json"),
+                            disable_lock=True)
+        return NodeIdentity(identity_file=store)
+
+    def test_forget_removes_only_the_named_pin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = self._make_identity(tmpdir)
+            identity.pin_noise_key("hive.example:5678", "aa" * 32)
+            identity.pin_noise_key("other.example:5678", "bb" * 32)
+
+            self.assertTrue(identity.forget_noise_key("hive.example:5678"))
+
+            self.assertEqual(identity.pinned_noise_keys,
+                             {"other.example:5678": "bb" * 32})
+
+    def test_forget_unknown_pin_reports_nothing_removed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = self._make_identity(tmpdir)
+            identity.pin_noise_key("hive.example:5678", "aa" * 32)
+
+            self.assertFalse(identity.forget_noise_key("nowhere:5678"))
+            self.assertEqual(identity.pinned_noise_keys,
+                             {"hive.example:5678": "aa" * 32})
+
+    def test_forget_survives_a_reload(self):
+        """The removal is written to disk, not only to the live dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from json_database import JsonStorage
+            from hivemind_bus_client.identity import NodeIdentity
+            path = os.path.join(tmpdir, "identity.json")
+            identity = self._make_identity(tmpdir)
+            identity.pin_noise_key("hive.example:5678", "aa" * 32)
+            identity.forget_noise_key("hive.example:5678")
+
+            reloaded = NodeIdentity(
+                identity_file=JsonStorage(path, disable_lock=True))
+            self.assertEqual(reloaded.pinned_noise_keys, {})
+
+
+class TestCorruptIdentityFile(unittest.TestCase):
+    """A node that cannot read its own identity must not become a new node.
+
+    The Noise static key path is derived from the node name, so falling
+    back to "unnamed-node" makes the node generate a fresh static key. To
+    every peer that pinned the old key it then looks like an impostor.
+    """
+
+    def _load(self, path):
+        from json_database import JsonStorage
+        from hivemind_bus_client.identity import NodeIdentity
+        return NodeIdentity(identity_file=JsonStorage(path, disable_lock=True))
+
+    def test_truncated_identity_file_raises(self):
+        from hivemind_bus_client.exceptions import IdentityFileCorrupted
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w") as f:
+                f.write('{"name": "kitchen", "password": "hunt')
+
+            with self.assertRaises(IdentityFileCorrupted):
+                self._load(path)
+
+    def test_missing_identity_file_mints_a_new_identity(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = self._load(os.path.join(tmpdir, "identity.json"))
+            self.assertEqual(identity.name, "unnamed-node")
+
+    def test_empty_identity_file_mints_a_new_identity(self):
+        """An empty object is what a first save() writes, not corruption."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w") as f:
+                f.write("{}")
+
+            self.assertEqual(self._load(path).name, "unnamed-node")
+
+    def test_readable_identity_file_loads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w") as f:
+                f.write('{"name": "kitchen"}')
+
+            self.assertEqual(self._load(path).name, "kitchen")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -340,6 +340,37 @@ class TestCorruptIdentityFile(unittest.TestCase):
 
             self.assertEqual(self._load(path).name, "unnamed-node")
 
+    def test_zero_byte_identity_file_raises(self):
+        """The likeliest corruption of all: the write truncated and stopped."""
+        from hivemind_bus_client.exceptions import IdentityFileCorrupted
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w"):
+                pass
+
+            with self.assertRaises(IdentityFileCorrupted):
+                self._load(path)
+
+    def test_whitespaced_empty_object_mints_a_new_identity(self):
+        """A templated placeholder is valid json and must boot."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w") as f:
+                f.write("{\n}\n")
+
+            self.assertEqual(self._load(path).name, "unnamed-node")
+
+    def test_identity_file_holding_a_list_raises(self):
+        """Valid json, but not an identity."""
+        from hivemind_bus_client.exceptions import IdentityFileCorrupted
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "identity.json")
+            with open(path, "w") as f:
+                f.write("[]")
+
+            with self.assertRaises(IdentityFileCorrupted):
+                self._load(path)
+
     def test_readable_identity_file_loads(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "identity.json")

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -119,10 +119,40 @@ class TestNoiseHandshakePinning:
 
         assert proto.hm.noise_transport is None
         proto.hm.handshake_event.set.assert_not_called()
-        proto.hm.close.assert_called_once()
+        # the transport-level close: the reconnect loop must survive
+        proto.hm.close_connection.assert_called_once()
+        proto.hm.close.assert_not_called()
         proto.identity.pin_noise_key.assert_not_called()
         assert any("pin" in call.args[0].lower() and "mismatch" in call.args[0].lower()
                    for call in error.call_args_list)
+
+    def test_mismatch_message_says_how_to_recover(self):
+        """The pin also trips on a legitimate rebuild of the master, so the
+        log line must name the way out instead of only shouting MITM.
+        """
+        remote_key = b"r" * 32
+        proto, message = self._make_protocol_at_noise_msg2(remote_key)
+        proto.identity.get_pinned_noise_key.return_value = b"p" * 32
+
+        with patch("hivemind_bus_client.protocol.NoiseTransport") as transport_cls:
+            transport_cls.return_value.remote_static_key = remote_key
+            with patch("hivemind_bus_client.protocol.LOG.error") as error:
+                proto.receive_noise_handshake(message)
+
+        logged = " ".join(call.args[0] for call in error.call_args_list)
+        assert "forget-server" in logged
+
+    def test_malformed_envelope_also_keeps_reconnecting(self):
+        """Every abort reason is repairable from the other side, so none of
+        them may stop the reconnect loop.
+        """
+        proto = _make_protocol()
+        message = HiveMessage(HiveMessageType.HANDSHAKE, {"noise": {}})
+
+        proto.receive_noise_handshake(message)
+
+        proto.hm.close_connection.assert_called_once()
+        proto.hm.close.assert_not_called()
 
     def test_pinned_key_matches_completes_handshake(self):
         """A pin that matches the negotiated static key is the expected,
@@ -141,7 +171,7 @@ class TestNoiseHandshakePinning:
 
         assert proto.hm.noise_transport is transport_cls.return_value
         proto.hm.handshake_event.set.assert_called_once()
-        proto.hm.close.assert_not_called()
+        proto.hm.close_connection.assert_not_called()
         proto.identity.pin_noise_key.assert_not_called()
 
     def test_no_pin_tofu_pins_new_key(self):
@@ -161,7 +191,7 @@ class TestNoiseHandshakePinning:
 
         assert proto.hm.noise_transport is transport_cls.return_value
         proto.hm.handshake_event.set.assert_called_once()
-        proto.hm.close.assert_not_called()
+        proto.hm.close_connection.assert_not_called()
         proto.identity.pin_noise_key.assert_called_once_with(
             proto._noise_pin_id, remote_key)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,96 @@
+"""Tests for the hivemind-client command line tools."""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from hivemind_bus_client.scripts import forget_server
+
+
+def _make_identity(tmpdir):
+    from json_database import JsonStorage
+    from hivemind_bus_client.identity import NodeIdentity
+    store = JsonStorage(os.path.join(tmpdir, "identity.json"),
+                        disable_lock=True)
+    identity = NodeIdentity(identity_file=store)
+    identity.default_master = "ws://hive.example"
+    identity.default_port = 5678
+    identity.pin_noise_key("hive.example:5678", "aa" * 32)
+    identity.pin_noise_key("other.example:5678", "bb" * 32)
+    identity.save()
+    return identity
+
+
+class TestForgetServer(unittest.TestCase):
+    """Recovering from a reinstalled master must not need a text editor."""
+
+    def test_forgets_only_the_named_server(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = _make_identity(tmpdir)
+            with patch("hivemind_bus_client.scripts.NodeIdentity",
+                       return_value=identity):
+                result = CliRunner().invoke(
+                    forget_server, ["--host", "hive.example", "--port", "5678"])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("forgot pinned key for hive.example:5678",
+                          result.output)
+            self.assertEqual(identity.pinned_noise_keys,
+                             {"other.example:5678": "bb" * 32})
+
+    def test_defaults_to_the_master_in_the_identity_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = _make_identity(tmpdir)
+            with patch("hivemind_bus_client.scripts.NodeIdentity",
+                       return_value=identity):
+                result = CliRunner().invoke(forget_server, [])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertNotIn("hive.example:5678", identity.pinned_noise_keys)
+
+    def test_accepts_a_host_with_a_scheme(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = _make_identity(tmpdir)
+            with patch("hivemind_bus_client.scripts.NodeIdentity",
+                       return_value=identity):
+                result = CliRunner().invoke(
+                    forget_server,
+                    ["--host", "ws://hive.example", "--port", "5678"])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertNotIn("hive.example:5678", identity.pinned_noise_keys)
+
+    def test_unknown_server_lists_what_is_pinned(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            identity = _make_identity(tmpdir)
+            with patch("hivemind_bus_client.scripts.NodeIdentity",
+                       return_value=identity):
+                result = CliRunner().invoke(
+                    forget_server, ["--host", "nowhere", "--port", "5678"])
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("no pinned key for nowhere:5678", result.output)
+            self.assertIn("hive.example:5678", result.output)
+            self.assertEqual(len(identity.pinned_noise_keys), 2)
+
+    def test_removal_is_written_to_disk(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from json_database import JsonStorage
+            from hivemind_bus_client.identity import NodeIdentity
+            identity = _make_identity(tmpdir)
+            path = identity.IDENTITY_FILE.path
+            with patch("hivemind_bus_client.scripts.NodeIdentity",
+                       return_value=identity):
+                CliRunner().invoke(
+                    forget_server, ["--host", "hive.example", "--port", "5678"])
+
+            reloaded = NodeIdentity(
+                identity_file=JsonStorage(path, disable_lock=True))
+            self.assertEqual(reloaded.pinned_noise_keys,
+                             {"other.example:5678": "bb" * 32})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes a severity-1 field defect, reproduced live.

## Problem

`_abort_noise` called `self.hm.close()`. That is the **public** close — the one documented as "Permanently stop reconnecting and close the websocket". It sets `_stop_event`, the reconnect worker loop exits, and the thread is dropped:

```
SAT connected=False handshake=False stop_event=True threads=1
```

The satellite never retries. Restarting the service does not help, because the cause of the abort is on disk. Only editing `~/.config/hivemind/_identity.json` by hand brings the node back.

The codebase already knew this was wrong in the analogous place. On an invalid Noise transport frame `on_message` deliberately uses the socket-level close, with the comment "Public close() is reserved for an intentional permanent shutdown." The handshake abort path never got that treatment.

This fires for **any** abort reason, not only a pinned-key mismatch: a password rotated on the master, a truncated handshake envelope, a malformed Noise envelope.

## Fixes

**Reconnect survives an abort.** Both clients grow a `close_connection()` next to `close()`, and `_abort_noise` calls it. The connection is refused, the reconnect loop lives, and the failure is re-logged on every attempt — visible instead of silent. TOFU security is unchanged: the node still refuses to talk to the new key. The invalid-frame path now calls the same method instead of reaching into `self.client`.

**`hivemind-client forget-server`.** The pin is keyed by *endpoint*, `host:port`, not by node. So any rebuild of the core at the same address trips it: a reinstall, a new SD card, another `ovos-installer` run, a restored backup. There was no supported way to clear a pin. The new command drops one pin, defaulting to the master in the identity file, and lists what is pinned when it finds nothing.

**An actionable error message.** The old line said a man-in-the-middle may be occurring and stopped there, which is alarming and gives no next step. It now names both cases and the command to run.

**Fail loudly on an unreadable identity file.** `JsonStorage` fails open: a truncated file logs and leaves the dict empty. `NodeIdentity` then fell back to defaults, called itself `unnamed-node`, and — because the Noise static key path is derived from the name — generated a **different static key**. Every satellite then sees its master replaced and hits the bug above. A node that cannot read its own identity now raises `IdentityFileCorrupted` instead of coming up as a different node. An absent or empty file still mints a new identity as before.

The write that leaves the file truncated is fixed in TigreGotico/json_database#39.

Along the way: `NodeIdentity(identity_file=...)` used a truthiness test, so a caller passing its own still-empty store silently got the global XDG identity instead.

## Tests

- `tests/test_client.py::TestHiveMessageBusClientHandshakeAbort` — an abort closes the socket and leaves `_stop_event` clear; end to end, an abort during `run_forever()` leads to a second socket; `close_connection()` does not stop reconnecting.
- `tests/test_protocol.py` — the mismatch path uses `close_connection`, never `close`; the log line names `forget-server`; a malformed envelope keeps reconnecting too.
- `tests/test_identity.py` — `forget_noise_key` removes exactly the named pin, leaves the others, reports an unknown pin, and survives a reload; a truncated identity file raises while missing and empty files do not.
- `tests/test_scripts.py` (new) — `forget-server` by host/port, defaulting to the identity file, accepting a `ws://` host, listing pins when the server is unknown, and writing the removal to disk.

Full suite: 462 passed, 4 skipped.