### PR TITLE
fix: make the flood id cache thread safe

### DIFF
--- a/hivemind_bus_client/hive_map.py
+++ b/hivemind_bus_client/hive_map.py
@@ -5,6 +5,7 @@ Every node responds to a PING by propagating its own PING (with the same
 ``flood_id`` prevents infinite loops.
 """
 import json
+import threading
 import time
 from collections import OrderedDict
 from collections.abc import MutableSet
@@ -57,30 +58,45 @@ class FloodIdCache(MutableSet):
     It behaves as a plain ``set`` of strings (``add``, ``in``, ``len``,
     iteration) so existing code and tests keep working, and adds
     :meth:`check` for the test-and-register step a flood handler needs.
+
+    The two halves of a node run on different threads — the listener on
+    the server IOLoop, the slave on its websocket client thread — so this
+    class carries its own lock. :meth:`check` is atomic: for one
+    ``flood_id``, exactly one caller ever gets ``False``.
     """
 
     def __init__(self, max_size: int = 1000) -> None:
         self.max_size = max_size
         # flood_id → insertion timestamp; ordered so eviction is FIFO
         self._ids: "OrderedDict[str, float]" = OrderedDict()
+        self._lock = threading.Lock()
 
     # --- MutableSet interface ---------------------------------------
 
     def __contains__(self, flood_id: object) -> bool:
-        return flood_id in self._ids
+        with self._lock:
+            return flood_id in self._ids
 
     def __iter__(self):
-        return iter(self._ids)
+        with self._lock:
+            return iter(list(self._ids))
 
     def __len__(self) -> int:
-        return len(self._ids)
+        with self._lock:
+            return len(self._ids)
 
     def __getitem__(self, flood_id: str) -> float:
         """Insertion time of *flood_id*, for age inspection and debugging."""
-        return self._ids[flood_id]
+        with self._lock:
+            return self._ids[flood_id]
 
     def add(self, flood_id: str) -> None:
         """Register *flood_id*, evicting the oldest entries when full."""
+        with self._lock:
+            self._add(flood_id)
+
+    def _add(self, flood_id: str) -> None:
+        """``add`` without the lock, for callers that already hold it."""
         if flood_id in self._ids:
             return
         while len(self._ids) >= self.max_size:
@@ -88,10 +104,12 @@ class FloodIdCache(MutableSet):
         self._ids[flood_id] = time.time()
 
     def discard(self, flood_id: str) -> None:
-        self._ids.pop(flood_id, None)
+        with self._lock:
+            self._ids.pop(flood_id, None)
 
     def clear(self) -> None:
-        self._ids.clear()
+        with self._lock:
+            self._ids.clear()
 
     # --- flood handling ---------------------------------------------
 
@@ -102,15 +120,19 @@ class FloodIdCache(MutableSet):
         must drop the message), ``False`` the first time (the caller
         handles it). An empty ``flood_id`` always reads as seen, so a
         malformed PING never triggers a response.
+
+        The test and the registration happen under one lock, so two
+        threads racing on the same ``flood_id`` cannot both win.
         """
         if not flood_id:
             return True
-        if flood_id in self._ids:
-            return True
-        if max_size is not None:
-            self.max_size = max_size
-        self.add(flood_id)
-        return False
+        with self._lock:
+            if flood_id in self._ids:
+                return True
+            if max_size is not None:
+                self.max_size = max_size
+            self._add(flood_id)
+            return False
 
 
 class HiveMapper:

--- a/tests/test_flood_cache.py
+++ b/tests/test_flood_cache.py
@@ -13,6 +13,7 @@ listener as its public key. The originator then maps one node as two.
 ``HiveMindSlaveProtocol.bind_flood_cache`` is how the listener hands its
 cache over.
 """
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -63,6 +64,47 @@ class TestFloodIdCache:
         cache.add("f2")
         cache.clear()
         assert len(cache) == 0
+
+    def test_check_is_atomic_across_threads(self):
+        """The two halves of a node race on one cache from two threads.
+
+        Only one of them may answer a given flood, so exactly one caller
+        gets ``False`` no matter how many threads ask at once.
+        """
+        cache = FloodIdCache()
+        winners = []
+        start = threading.Barrier(16)
+
+        def contend():
+            start.wait()
+            if not cache.check("contended-flood"):
+                winners.append(threading.current_thread().name)
+
+        threads = [threading.Thread(target=contend) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(winners) == 1
+
+    def test_concurrent_adds_keep_the_cache_bounded(self):
+        """Eviction under contention must not corrupt the ordered store."""
+        cache = FloodIdCache(max_size=50)
+        start = threading.Barrier(8)
+
+        def fill(offset):
+            start.wait()
+            for i in range(200):
+                cache.check(f"f-{offset}-{i}")
+
+        threads = [threading.Thread(target=fill, args=(n,)) for n in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(cache) == 50
 
 
 class TestHiveMapperUsesTheCache:


### PR DESCRIPTION
A node with an upstream runs two protocol objects that share one `FloodIdCache`: the listener half on the server IOLoop, the slave half on the bus client websocket thread.

The cache was a plain `OrderedDict` with no lock. `check()` tested membership and registered the id in two separate steps, so two threads could both read "not seen" for one `flood_id` and both answer the flood. The slave answers as its connection peer and the listener as its public key, so the originator records one node twice — the exact failure that sharing the cache was added to prevent.

## Change

`FloodIdCache` now owns a `threading.Lock`. The lock lives in the shared object because that is what the two halves share. `check()` tests and registers under it, so for one `flood_id` exactly one caller ever gets `False`. `add`, `discard`, `clear`, `__contains__`, `__len__`, `__getitem__` and iteration take the same lock.

No signature changed, `check(flood_id, max_size=...)` included.

## Tests

- `test_check_is_atomic_across_threads` — 16 threads race on one `flood_id`; exactly one wins.
- `test_concurrent_adds_keep_the_cache_bounded` — 8 threads, 1600 ids, `max_size=50`; FIFO eviction under contention leaves the store intact.

Full suite: 447 passed, 4 skipped.