### PR TITLE
fix: bound how long a QUERY originator waits (NODE-1 §5.5)

### DIFF
--- a/hivemind_bus_client/protocol.py
+++ b/hivemind_bus_client/protocol.py
@@ -32,6 +32,8 @@ from poorman_handshake.asymmetric.utils import load_RSA_key
 # wrapping this control message (protocol contract with hivemind-core; the
 # end-of-stream is content, not metadata).
 QUERY_STREAM_END = "hive.query.complete"
+# emitted by the node at the top of the chain when nothing answered (AGENT-1 §5)
+QUERY_TIMEOUT = "hive.query.timeout"
 
 
 def _pw_min_bits() -> float:
@@ -130,6 +132,80 @@ class CascadeAggregator:
             self._resolved = True
 
 
+class QueryTimeoutGuard:
+    """Bounds how long the originator of a QUERY waits for the mesh to answer.
+
+    HIVEMIND-NODE-1 §5.5 (and HIVEMIND-AGENT-1 §5) require the originator to
+    treat a query as failed when no chunk, no ``hive.query.complete`` and no
+    ``hive.query.timeout`` arrives within a configured interval. Without it a
+    vanished intermediate node strands the originator forever.
+
+    Shaped after :class:`CascadeAggregator`: one daemon ``threading.Timer``,
+    one lock, resolve-once semantics. The difference is what starts the clock —
+    a CASCADE window opens on the *first response*, a QUERY window opens when
+    the query is *sent*, because the failure being bounded is getting nothing
+    at all. Every chunk restarts the clock, so a slow stream is not killed
+    mid-flight.
+
+    Like ``cascade_aggregator`` this is a single per-connection window rather
+    than a table keyed by query id: the originator does not know its query id
+    until the answers come back, because the id is minted by the node that
+    admits the query.
+
+    Args:
+        timeout: Seconds of silence tolerated before the query is failed.
+        emit_callback: Called with the last seen ``query_id`` on expiry.
+    """
+
+    def __init__(self, timeout: float, emit_callback: Callable[[str], None]) -> None:
+        self.timeout = timeout
+        self.emit_callback = emit_callback
+        self.query_id = ""
+        self._timer: Optional[threading.Timer] = None
+        self._lock = threading.Lock()
+        self._resolved = False
+
+    def start(self) -> None:
+        """Open the window. Called when the QUERY leaves the originator."""
+        with self._lock:
+            self._resolved = False
+            self.query_id = ""
+            self._restart()
+
+    def keepalive(self, query_id: str = "") -> None:
+        """Restart the window because a chunk arrived."""
+        with self._lock:
+            if self._resolved:
+                return
+            if query_id:
+                self.query_id = query_id
+            self._restart()
+
+    def _restart(self) -> None:
+        """Caller must hold ``_lock``."""
+        if self._timer is not None:
+            self._timer.cancel()
+        self._timer = threading.Timer(self.timeout, self._expire)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _expire(self) -> None:
+        with self._lock:
+            if self._resolved:
+                return
+            self._resolved = True
+            self._timer = None
+        self.emit_callback(self.query_id)
+
+    def cancel(self) -> None:
+        """Close the window without failing — the answer stream completed."""
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+            self._resolved = True
+
+
 @dataclass()
 class HiveMindSlaveInternalProtocol:
     """ this class handles all interactions between a hivemind listener and a ovos-core messagebus"""
@@ -137,6 +213,7 @@ class HiveMindSlaveInternalProtocol:
     share_bus: bool = False
     bus: Optional[MessageBusClient] = None
     node_id: str = ""  # this is how ovos-core bus refers to this slave's master
+    slave_protocol: Optional["HiveMindSlaveProtocol"] = None
 
     def register_bus_handlers(self):
         self.bus.on("hive.send.upstream", self.handle_send) # meant for internal usage by agent protocol plugins
@@ -163,6 +240,8 @@ class HiveMindSlaveInternalProtocol:
             pass
         else:
             self.hm_bus.emit(hmessage)
+            if msg_type == HiveMessageType.QUERY and self.slave_protocol is not None:
+                self.slave_protocol.arm_query_timeout()
 
     def handle_outgoing_mycroft(self, message: Message):
         """ forward internal messages to masters"""
@@ -205,9 +284,11 @@ class HiveMindSlaveProtocol:
     binarize: bool = False
     site_id: str = "unknown"
     cascade_timeout: float = 5.0
+    query_timeout: float = 30.0
     cascade_select_callback: Optional[Callable[[List[HiveMessage]], Optional[HiveMessage]]] = None
     hive_mapper: Optional[HiveMapper] = None
     cascade_aggregator: Optional[CascadeAggregator] = field(default=None, repr=False)
+    query_guard: Optional[QueryTimeoutGuard] = field(default=None, repr=False)
     # protocol v3 (Noise handshake) state — HIVEMIND-CRYPTO-1 §3.4
     noise_handshake: Optional[object] = field(default=None, repr=False)
     _noise_pattern: Optional[str] = field(default=None, repr=False)
@@ -249,7 +330,8 @@ class HiveMindSlaveProtocol:
             bus.run_in_thread()
             bus.connected_event.wait()
         LOG.info("Initializing HiveMindSlaveInternalProtocol")
-        self.internal_protocol = HiveMindSlaveInternalProtocol(bus=bus, hm_bus=self.hm)
+        self.internal_protocol = HiveMindSlaveInternalProtocol(bus=bus, hm_bus=self.hm,
+                                                               slave_protocol=self)
         self.internal_protocol.register_bus_handlers()
         LOG.info("registering protocol handlers")
         self.hm.on(HiveMessageType.HELLO, self.handle_hello)
@@ -750,6 +832,31 @@ class HiveMindSlaveProtocol:
         return (inner.msg_type == HiveMessageType.BUS
                 and getattr(inner.payload, "msg_type", "") == QUERY_STREAM_END)
 
+    def arm_query_timeout(self) -> None:
+        """Open the originator-side liveness window for a QUERY we just sent.
+
+        HIVEMIND-NODE-1 §5.5 — the originator, not the mesh, is responsible
+        for bounding how long it waits.
+        """
+        if self.query_guard is None:
+            self.query_guard = QueryTimeoutGuard(timeout=self.query_timeout,
+                                                 emit_callback=self._emit_query_timeout)
+        self.query_guard.start()
+
+    def _emit_query_timeout(self, query_id: str) -> None:
+        """Report the expired query on the internal bus.
+
+        Uses the HIVEMIND-AGENT-1 §5 payload shape, with
+        ``error="originator_timeout"`` so a consumer can tell "nobody
+        answered in time" apart from the mesh's own ``no_answer``, which
+        means the query was answered with nothing.
+        """
+        LOG.warning(f"QUERY timed out after {self.query_timeout}s: {query_id}")
+        self.internal_protocol.bus.emit(
+            Message("hive.query.timeout", {"query_id": query_id,
+                                           "error": "originator_timeout"})
+        )
+
     def handle_query(self, message: HiveMessage):
         """Handle a QUERY message received from the master.
 
@@ -760,10 +867,20 @@ class HiveMindSlaveProtocol:
         """
         LOG.info(f"QUERY: {message.payload}")
         assert message.msg_type == HiveMessageType.QUERY
+        query_id = (message.metadata or {}).get("query_id", "")
+        inner = message.payload
+        terminal = self._is_stream_end(message) or (
+            inner.msg_type == HiveMessageType.BUS
+            and getattr(inner.payload, "msg_type", "") == QUERY_TIMEOUT
+        )
+        if terminal and self.query_guard is not None:
+            # the mesh reported the outcome in time; our own window is moot
+            self.query_guard.cancel()
         if self._is_stream_end(message):
-            LOG.debug("QUERY stream complete: "
-                      f"{(message.metadata or {}).get('query_id')}")
+            LOG.debug(f"QUERY stream complete: {query_id}")
             return
+        if not terminal and self.query_guard is not None:
+            self.query_guard.keepalive(query_id)
         assert message.payload.msg_type in [HiveMessageType.BUS, HiveMessageType.INTERCOM]
         if message.payload.msg_type == HiveMessageType.INTERCOM:
             # using INTERCOM allows end2end privacy, nodes along the chain can't read responses

--- a/tests/test_query_timeout.py
+++ b/tests/test_query_timeout.py
@@ -1,0 +1,143 @@
+"""Originator-side QUERY liveness bound (HIVEMIND-NODE-1 §5.5, AGENT-1 §5).
+
+NODE-1 §5.5 requires the originator of a QUERY to treat it as failed when no
+chunk, no ``hive.query.complete`` and no ``hive.query.timeout`` arrives within
+a configured interval. CASCADE has always had such a window
+(``cascade_timeout``); QUERY had none, so a vanished intermediate node stranded
+the originator forever.
+
+The failure is reported as ``hive.query.timeout`` with
+``error="originator_timeout"`` — deliberately distinct from the mesh's own
+``error="no_answer"``, which means the query *was* resolved and nothing had an
+answer.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+
+from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.protocol import (HiveMindSlaveInternalProtocol,
+                                          HiveMindSlaveProtocol,
+                                          QueryTimeoutGuard,
+                                          QUERY_STREAM_END, QUERY_TIMEOUT)
+
+
+def _make_protocol(query_timeout=0.05):
+    hm = MagicMock()
+    hm.session_id = "test-session"
+    identity = MagicMock(spec=NodeIdentity)
+    identity.name = "test-node"
+    proto = HiveMindSlaveProtocol(hm=hm, identity=identity,
+                                  query_timeout=query_timeout)
+    proto.internal_protocol = MagicMock()
+    proto.internal_protocol.bus = MagicMock()
+    return proto
+
+
+def _query(payload_type, query_id="q-1"):
+    inner = HiveMessage(HiveMessageType.BUS,
+                        {"type": payload_type, "data": {}, "context": {}})
+    return HiveMessage(HiveMessageType.QUERY, payload=inner,
+                       metadata={"query_id": query_id})
+
+
+def _emitted(proto):
+    return [c[0][0] for c in proto.internal_protocol.bus.emit.call_args_list
+            if isinstance(c[0][0], Message)]
+
+
+def _originator_timeouts(proto):
+    return [m for m in _emitted(proto)
+            if m.msg_type == QUERY_TIMEOUT
+            and m.data.get("error") == "originator_timeout"]
+
+
+class TestQueryTimeoutGuard:
+    """NODE-1 §5.5: the window exists, expires, and is cancellable."""
+
+    def test_window_expires_when_nothing_arrives(self):
+        fired = []
+        guard = QueryTimeoutGuard(timeout=0.05, emit_callback=fired.append)
+        guard.start()
+        assert fired == []
+        time.sleep(0.15)
+        assert fired == [""]
+
+    def test_keepalive_extends_the_window(self):
+        fired = []
+        guard = QueryTimeoutGuard(timeout=0.15, emit_callback=fired.append)
+        guard.start()
+        for _ in range(3):
+            time.sleep(0.08)
+            guard.keepalive("q-1")
+        assert fired == []
+        time.sleep(0.25)
+        assert fired == ["q-1"]
+
+    def test_cancel_prevents_expiry(self):
+        fired = []
+        guard = QueryTimeoutGuard(timeout=0.05, emit_callback=fired.append)
+        guard.start()
+        guard.cancel()
+        time.sleep(0.15)
+        assert fired == []
+
+
+class TestOriginatorQueryTimeout:
+    """NODE-1 §5.5 end to end on HiveMindSlaveProtocol."""
+
+    def test_silence_after_sending_a_query_is_reported_as_a_failure(self):
+        proto = _make_protocol()
+        proto.arm_query_timeout()
+        time.sleep(0.2)
+        msgs = _emitted(proto)
+        assert [m.msg_type for m in msgs] == [QUERY_TIMEOUT]
+        assert msgs[0].data["error"] == "originator_timeout"
+        assert msgs[0].data["query_id"] == ""
+
+    def test_a_timeout_is_distinguishable_from_answered_with_nothing(self):
+        # the mesh's own verdict uses error="no_answer" and must not be
+        # confused with the originator giving up
+        proto = _make_protocol()
+        proto.arm_query_timeout()
+        assert proto.internal_protocol.bus.emit.call_count == 0
+        time.sleep(0.2)
+        assert _emitted(proto)[0].data["error"] != "no_answer"
+
+    def test_an_answer_chunk_keeps_the_query_alive(self):
+        proto = _make_protocol(query_timeout=0.2)
+        proto.arm_query_timeout()
+        for _ in range(3):
+            time.sleep(0.1)
+            proto.handle_query(_query("speak"))
+        assert _originator_timeouts(proto) == []
+
+    def test_stream_completion_closes_the_window(self):
+        proto = _make_protocol()
+        proto.arm_query_timeout()
+        proto.handle_query(_query(QUERY_STREAM_END))
+        time.sleep(0.2)
+        assert _originator_timeouts(proto) == []
+
+    def test_a_mesh_timeout_verdict_closes_the_window(self):
+        proto = _make_protocol()
+        proto.arm_query_timeout()
+        proto.handle_query(_query(QUERY_TIMEOUT))
+        time.sleep(0.2)
+        # the mesh verdict is relayed to the app, and the originator does not
+        # pile its own failure on top of it
+        assert [m.msg_type for m in _emitted(proto)] == [QUERY_TIMEOUT]
+        assert _originator_timeouts(proto) == []
+
+    def test_sending_a_query_upstream_arms_the_window(self):
+        proto = _make_protocol()
+        internal = HiveMindSlaveInternalProtocol(hm_bus=MagicMock(), bus=MagicMock(),
+                                                 slave_protocol=proto)
+        internal.handle_send(Message("hive.send.upstream",
+                                     {"msg_type": HiveMessageType.QUERY,
+                                      "payload": {"type": "recognizer_loop:utterance"}}))
+        assert proto.query_guard is not None
+        proto.query_guard.cancel()


### PR DESCRIPTION
## The defect

NODE-1 §5.5 (restated by AGENT-1 §5) requires the **originator** of a QUERY to treat it as failed when no chunk, no `hive.query.complete` and no `hive.query.timeout` arrives within a configured interval.

`HiveMindSlaveProtocol.handle_query` had no timer at all. CASCADE has had one since it was written (`cascade_timeout: float = 5.0`, `CascadeAggregator`). If an intermediate node vanishes mid-query the originator waits forever.

## The fix

`QueryTimeoutGuard`, shaped after `CascadeAggregator` on purpose — one daemon `threading.Timer`, one lock, resolve-once semantics, a `cancel()` that closes the window without firing, and a plain `query_timeout: float` field on the protocol next to `cascade_timeout`.

One deliberate difference, documented in the class docstring: a CASCADE window opens on the *first response*, a QUERY window opens when the query is *sent*, because the failure being bounded here is getting nothing at all. Every chunk restarts it, so a slow stream is not killed mid-flight.

### What the originator observes

`hive.query.timeout` on the internal bus with `query_id` and `error="originator_timeout"`.

That is the AGENT-1 §5 payload shape, with an error value deliberately distinct from the mesh's own `no_answer`. `no_answer` means the query *was* resolved and nothing had an answer; `originator_timeout` means nobody said anything at all. A consumer that cannot tell those apart cannot decide whether retrying is worthwhile.

When the mesh's own `hive.query.timeout` does arrive in time, it is relayed to the app and the guard is cancelled — the originator never piles its own verdict on top of the mesh's.

## Backwards compatibility

**No wire change whatsoever.** The guard is a timer and a bus emission inside the originator process. Nothing new is sent, nothing new is expected, no field is added to any frame. Non-Python clients are unaffected — an originator liveness bound is something each implementation adopts on its own schedule.

The only structural change is a new optional `slave_protocol` field on `HiveMindSlaveInternalProtocol`, so origination via `hive.send.upstream` can arm the window. It defaults to `None` and every existing construction keeps working.

## Pinning test

`tests/test_query_timeout.py`, docstring citing NODE-1 §5.5 / AGENT-1 §5. Nine tests over two classes:

- the guard: expires on silence, `keepalive` extends it, `cancel` prevents it
- the protocol: silence after sending is reported as a failure; the failure is distinguishable from "answered with nothing"; an answer chunk keeps the query alive; stream completion closes the window; a mesh timeout verdict closes the window; sending a QUERY upstream arms the window

**Red then green:** with the production change reverted the module fails to import — `QueryTimeoutGuard`, `QUERY_TIMEOUT` and `query_timeout` do not exist on `origin/dev`, which is exactly the gap. Restored, all nine pass.

## Test runs

`~/.venvs/ovos/bin/python -m pytest tests -q -p no:ovoscope -p no:recording --timeout=900`

- unmodified `origin/dev`: 445 passed, 4 skipped
- this branch: 454 passed, 4 skipped

No pre-existing failures in this repo, and none added. Two `test_protocol_v3_matrix` e2e tests flaked once under full-suite load and pass on a clean re-run; they are timing-sensitive and unrelated to this change.

## Source

Item NODE-1 §5.5 / AGENT-1 §5 of the 2026-08-04 spec/implementation conformance baseline.